### PR TITLE
Fix up the MIDI podule implementation so it works with external hardware

### DIFF
--- a/podules/common/midi/midi_alsa.c
+++ b/podules/common/midi/midi_alsa.c
@@ -256,6 +256,13 @@ void midi_write(void *p, uint8_t val)
                         
         if (midi->len)
         {                
+                if (midi->pos > midi->len)
+                {
+                    /* It's a repeated command */
+                    midi->pos = 1;
+                    midi->command &= 0xff;
+                }
+            
                 midi->command |= (val << (midi->pos * 8));
                 
                 midi->pos++;

--- a/podules/common/midi/midi_win.c
+++ b/podules/common/midi/midi_win.c
@@ -20,8 +20,6 @@ typedef struct midi_t
         void *p;
 } midi_t;
 
-static int midi_id;
-
 void midi_close();
 
 void midi_get_dev_name(int num, char *s);
@@ -53,7 +51,6 @@ void *midi_init(void *p, void (*receive)(void *p, uint8_t val), void (*log)(cons
         midi->p = p;
         midi->receive = receive;
         
-        midi_id = 0;//config_get_int(CFG_MACHINE, NULL, "midi", 0);
         if (log)
                 log("num_out_devs=%i\n", midiOutGetNumDevs());
         for (c = 0; c < midiOutGetNumDevs(); c++)
@@ -72,13 +69,13 @@ void *midi_init(void *p, void (*receive)(void *p, uint8_t val), void (*log)(cons
                         log("name%i = %s\n", c, name);
         }
 
-        hr = midiOutOpen(&midi->out_device, midi_id, 0,
-		   0, CALLBACK_NULL);
+        hr = midiOutOpen(&midi->out_device, midi_out_dev_nr, 0,
+           0, CALLBACK_NULL);
         if (hr != MMSYSERR_NOERROR) {
 //                lark_log("midiOutOpen error - %08X\n",hr);
-                midi_id = 0;
-                hr = midiOutOpen(&midi->out_device, midi_id, 0,
-        		   0, CALLBACK_NULL);
+                midi_out_dev_nr = 0;
+                hr = midiOutOpen(&midi->out_device, midi_out_dev_nr, 0,
+                   0, CALLBACK_NULL);
                 if (hr != MMSYSERR_NOERROR) {
 //                        lark_log("midiOutOpen error - %08X\n",hr);
                         return midi;
@@ -86,14 +83,13 @@ void *midi_init(void *p, void (*receive)(void *p, uint8_t val), void (*log)(cons
         }
         midiOutReset(midi->out_device);
 
-        midi_id = 0;
-        hr = midiInOpen(&midi->in_device, midi_id, (DWORD)(void *)midi_in_callback,
-		   (DWORD)midi, CALLBACK_FUNCTION);
+        hr = midiInOpen(&midi->in_device, midi_in_dev_nr, (DWORD)(void *)midi_in_callback,
+           (DWORD)midi, CALLBACK_FUNCTION);
         if (hr != MMSYSERR_NOERROR) {
 //                lark_log("midiInOpen error - %08X\n",hr);
-                midi_id = 0;
-                hr = midiInOpen(&midi->in_device, midi_id, (DWORD)(void *)midi_in_callback,
-        		   (DWORD)midi, CALLBACK_FUNCTION);
+                midi_in_dev_nr = 0;
+                hr = midiInOpen(&midi->in_device, midi_in_dev_nr, (DWORD)(void *)midi_in_callback,
+                   (DWORD)midi, CALLBACK_FUNCTION);
                 if (hr != MMSYSERR_NOERROR) {
 //                        lark_log("midiInOpen error - %08X\n",hr);
                         return midi;

--- a/podules/common/midi/midi_win.c
+++ b/podules/common/midi/midi_win.c
@@ -216,6 +216,13 @@ void midi_write(void *p, uint8_t val)
                         
         if (midi->len)
         {
+                if (midi->pos > midi->len)
+                {
+                    /* It's a repeated command */
+                    midi->pos = 2;
+                    midi->buffer[1] = val;
+                }
+            
                 if (midi->pos == midi->len)
                         midi_send(midi);
         }


### PR DESCRIPTION
There's a pair of fixes here.
Firstly, fix the device selection so that it uses the device(s) selected via the configuration UI - Win only fix.
Then fix the playback so that "running status" (repeated commands) are handled - nominal fix for both Win & ALSA.
Tested with an emulated A540, Lark podule, MIDI Works and lots of MIDI files, USB to MIDI adaptor, XG synth hardware.
