### PR TITLE
Add config name as optional command line parameter.

### DIFF
--- a/src/wx-app.cc
+++ b/src/wx-app.cc
@@ -25,6 +25,7 @@
 extern "C"
 {
         #include "arc.h"
+        #include "config.h"
         #include "disc.h"
         #include "plat_joystick.h"
         #include "plat_video.h"
@@ -101,7 +102,7 @@ Frame::Frame(App* app, const wxString& title, const wxPoint& pos,
 
 void Frame::Start()
 {
-        if (!ShowConfigSelection())
+        if (strlen(machine_config_name) != 0 || !ShowConfigSelection())
                 arc_start_main_thread(this, this->menu);
         else
                 Quit(0);

--- a/src/wx-config_sel.cc
+++ b/src/wx-config_sel.cc
@@ -31,7 +31,6 @@ private:
 	void OnConfig(wxCommandEvent &event);
 
         void BuildConfigList();
-        wxString GetConfigPath(wxString config_name);
 };
 
 ConfigSelDialog::ConfigSelDialog(wxWindow* parent)
@@ -64,10 +63,6 @@ void ConfigSelDialog::BuildConfigList()
         }
         items.Sort();
         list->Set(items);
-}
-wxString ConfigSelDialog::GetConfigPath(wxString config_name)
-{
-        return wxString(exname) + "configs/" + config_name + ".cfg";
 }
 
 void ConfigSelDialog::OnOK(wxCommandEvent &event)
@@ -185,4 +180,9 @@ int ShowConfigSelection()
         ConfigSelDialog dlg(NULL);
         
         return dlg.ShowModal();
+}
+
+wxString GetConfigPath(wxString config_name)
+{
+        return wxString(exname) + "configs/" + config_name + ".cfg";
 }

--- a/src/wx-config_sel.h
+++ b/src/wx-config_sel.h
@@ -1,1 +1,2 @@
 int ShowConfigSelection();
+wxString GetConfigPath(wxString config_name);

--- a/src/wx-main.cc
+++ b/src/wx-main.cc
@@ -2,6 +2,8 @@
   Main function*/
 #include "wx-app.h"
 #include <SDL2/SDL.h>
+#include <wx/filename.h>
+#include "wx-config_sel.h"
 
 extern "C"
 {
@@ -18,6 +20,22 @@ int main(int argc, char **argv)
         strncpy(exname, argv[0], 511);
         char *p = (char *)get_filename(exname);
         *p = 0;
+
+        if(argc > 1)
+        {
+                wxString config_path = GetConfigPath(argv[1]);
+
+                if(wxFileName(config_path).Exists())
+                {
+                        strcpy(machine_config_file, config_path.mb_str());
+                        strcpy(machine_config_name, argv[1]);
+                }
+                else
+                {
+                        wxMessageBox("A configuration with the name '" + wxString(argv[1]) + "' does not exist", "Arculator", wxOK | wxCENTRE | wxSTAY_ON_TOP);
+                        exit(-1);
+                }
+        }
 
         podule_build_list();
         opendlls();


### PR DESCRIPTION
If the config exists then the config selection window is skipped, thereby booting directly into the emulator with the specified config.

This was requested in #1.