### PR TITLE
Make arm3cp structure unique

### DIFF
--- a/src/cp15.c
+++ b/src/cp15.c
@@ -7,6 +7,7 @@
 #include "vidc.h"
 
 int cp15_cacheon;
+struct _arm3cp arm3cp;
 
 void resetcp15()
 {

--- a/src/cp15.h
+++ b/src/cp15.h
@@ -1,7 +1,8 @@
-extern int cp15_cacheon;
-
-struct
+struct _arm3cp
 {
         uint32_t ctrl;
         uint32_t cache,update,disrupt;
-} arm3cp;
+};
+
+extern int cp15_cacheon;
+extern struct _arm3cp arm3cp;


### PR DESCRIPTION
This avoids creating a duplicate copy of the structure every time cp15.h is #included.  Fixes a linker error on my system (Fedora 33) about the duplicate definition.