### PR TITLE
Change include from <SDL2/SDL.h> to <SDL.h>

### DIFF
--- a/src/input_sdl2.c
+++ b/src/input_sdl2.c
@@ -1,6 +1,6 @@
 /*Arculator 2.0 by Sarah Walker
   SDL2 input handling*/
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <string.h>
 #include "arc.h"
 #include "plat_input.h"

--- a/src/keyboard_sdl.h
+++ b/src/keyboard_sdl.h
@@ -1,4 +1,4 @@
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #define KEY_ESC               SDL_SCANCODE_ESCAPE     /* keyboard scan codes  */
 #define KEY_1                 SDL_SCANCODE_1

--- a/src/video_sdl2.c
+++ b/src/video_sdl2.c
@@ -1,6 +1,6 @@
 /*Arculator 2.0 by Sarah Walker
   SDL2 video handling*/
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #if WIN32
 #define BITMAP __win_bitmap

--- a/src/wx-app.cc
+++ b/src/wx-app.cc
@@ -2,7 +2,7 @@
   wxApp implementation
   Menus are also handled here*/
 #include <sstream>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #ifdef _WIN32
 #define BITMAP WINDOWS_BITMAP

--- a/src/wx-main.cc
+++ b/src/wx-main.cc
@@ -1,7 +1,7 @@
 /*Arculator 2.0 by Sarah Walker
   Main function*/
 #include "wx-app.h"
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <wx/filename.h>
 #include "wx-config_sel.h"
 

--- a/src/wx-sdl2-joystick.c
+++ b/src/wx-sdl2-joystick.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include "arc.h"
 #include "joystick.h"
 #include "plat_joystick.h"


### PR DESCRIPTION
To compile on my Mac I needed to change the SDL includes. I've confirmed this still builds successfully on Linux (Debian buster) after making the change but don't know if it would still work on Windows (and have no Windows machine to test on.)