### PR TITLE
Add missing Makefile output for morley_uap podule

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -122,4 +122,4 @@ AM_CONDITIONAL(BUILD_PODULES, [test "$enable_podules" != "no"])
 
 AC_OUTPUT([Makefile src/Makefile])
 
-AC_OUTPUT([podules/aka05/src/Makefile podules/aka10/src/Makefile podules/aka12/src/Makefile podules/aka16/src/Makefile podules/aka31/src/Makefile podules/lark/src/Makefile podules/midimax/src/Makefile podules/oak_scsi/src/Makefile podules/ultimatecdrom/src/Makefile])
+AC_OUTPUT([podules/aka05/src/Makefile podules/aka10/src/Makefile podules/aka12/src/Makefile podules/aka16/src/Makefile podules/aka31/src/Makefile podules/lark/src/Makefile podules/midimax/src/Makefile podules/morley_uap/src/Makefile podules/oak_scsi/src/Makefile podules/ultimatecdrom/src/Makefile])


### PR DESCRIPTION
The morley_uap podule was missing a generated Makefile as it wasn't included in AC_OUTPUT, causing a compilation error; this fixes that issue.