### PR TITLE
Ignore "." and ".." when scanning podule ROMs

### DIFF
--- a/src/podules-linux.c
+++ b/src/podules-linux.c
@@ -57,7 +57,7 @@ void opendlls(void)
                 dll_t *dll = malloc(sizeof(dll_t));
                 memset(dll, 0, sizeof(dll_t));
 
-                if (dp->d_type != DT_DIR)
+                if (dp->d_type != DT_DIR || dp->d_name[0] == '.')
                 {
                         free(dll);
                         continue;


### PR DESCRIPTION
"." and ".." are actual directory entries in Linux; these should be ignored when scanning for podule subdirectories.