### PR TITLE
roms/podules/zidefs_a3k/roms.txt: mis-cased file

### DIFF
--- a/roms/podules/zidefs_a3k/roms.txt
+++ b/roms/podules/zidefs_a3k/roms.txt
@@ -1,2 +1,2 @@
 This directory contains the ROM for the ZIDEFS 8-bit IDE Controller. It is
-called 'ZIDEFSROM' and is a maximum of 16kB long.
+called 'zidefsrom' and is a maximum of 16kB long.


### PR DESCRIPTION
This roms.txt file has the filename in upper-case when it should be in lower-case.

This is the pull request referred to in issue #16!