### PR TITLE
Improve input latency by one frame

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -328,11 +328,11 @@ static int ddnoise_frames = 0;
 void arc_run()
 {
 	LOG_EVENT_LOOP("arc_run()\n");
-	execarm((speed_mhz * 1000000) / 100);
 	joystick_poll_host();
 	mouse_poll_host();
 	keyboard_poll_host();
 	if (mousehack) doosmouse();
+	execarm((speed_mhz * 1000000) / 100);
 	frameco++;
 	ddnoise_frames++;
 	if (ddnoise_frames == 10)


### PR DESCRIPTION
This improves input latency, and is particularly noticeable for the mouse cursor. It ensures that keyboard_poll gets the most recent values from the host OS. I don't think this change should affect emulation accuracy in any way.