### PR TITLE
Allow building with autoconf 2.69

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 # configure.ac for Arculator
 #
 
-AC_PREREQ([2.71])
+AC_PREREQ([2.69])
 AC_INIT([Arculator],[v2.0],[Sarah Walker <b-em@bbcmicro.com>],[arculator])
 
 AC_CANONICAL_HOST


### PR DESCRIPTION
This is the version of autoconf that's included in Debian stable.