### PR TITLE
Typos in readme.txt: "AEH53" should be "AEH54", description shouldn't have "both"

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -86,8 +86,8 @@ The podules supplied are :
 - Acorn AEH50 Ethernet II
 	Supported on both RISC OS and RISCiX. See Readme-NETWORKING.txt for setup details.
 
-- Acorn AEH53 Ethernet III
-	Supported on both RISC OS only. See Readme-NETWORKING.txt for setup details.
+- Acorn AEH54 Ethernet III
+	Supported on RISC OS only. See Readme-NETWORKING.txt for setup details.
 
 - Acorn AKA05 ROM Podule
 	Supports up to 5 ROMs per podule, plus up to 2 banks of RAM. Battery backed RAM is not


### PR DESCRIPTION
Wanted to get this in quickly before the v2.2 release! There's a typo in the name of one of the podules added in this release in the readme.