### PR TITLE
Fix append_filename() to work reliably

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -46,7 +46,11 @@ char *get_filename(char *s)
 
 void append_filename(char *dest, const char *s1, const char *s2, int size)
 {
-	sprintf(dest, "%s%s", s1, s2);
+	char *tmp_s1 = strdup(s1);
+	char *tmp_s2 = strdup(s2);
+	snprintf(dest, size, "%s%s", tmp_s1, tmp_s2);
+	free(tmp_s1);
+	free(tmp_s2);
 }
 
 void append_slash(char *s, int size)


### PR DESCRIPTION
sprintf() has undefined behaviour when destination and a source both point to the same buffer.  This happens in podule-linux.c and causes random failures to find the podule shared objects as in https://github.com/sarah-walker-pcem/arculator/issues/11

Using strdup() to create temporary copies of the source buffers eliminates the undefined behaviour.