### PR TITLE
Use SDL_CFLAGS rather than substituting result from sdl2-config --cflags

### DIFF
--- a/podules/aka10/src/Makefile.am
+++ b/podules/aka10/src/Makefile.am
@@ -42,7 +42,7 @@ if OS_MACOSX
 libaka10_la_SOURCES += ../../common/midi/midi_null.c
 endif
 
-libaka10_la_CFLAGS = -I../../../src -I../../common/adc -I../../common/joystick -I../../common/midi -I../../common/misc -I../../common/uart $(shell sdl2-config --cflags)
+libaka10_la_CFLAGS = -I../../../src -I../../common/adc -I../../common/joystick -I../../common/midi -I../../common/misc -I../../common/uart $(SDL_CFLAGS)
 libaka10_la_LIBADD = @LIBS@
 
 if OS_WINDOWS

--- a/podules/aka31/src/Makefile.am
+++ b/podules/aka31/src/Makefile.am
@@ -42,7 +42,7 @@ if OS_MACOSX
 libaka31_la_SOURCES += ../../common/cdrom/cdrom-osx-ioctl.c
 endif
 
-libaka31_la_CFLAGS = -I../../../src -I../../common/cdrom -I../../common/sound -I../../common/scsi
+libaka31_la_CFLAGS = $(SDL_CFLAGS) -I../../../src -I../../common/cdrom -I../../common/sound -I../../common/scsi
 libaka31_la_LIBADD = @LIBS@
 
 endif

--- a/podules/lark/src/Makefile.am
+++ b/podules/lark/src/Makefile.am
@@ -42,7 +42,7 @@ if OS_MACOSX
 liblark_la_SOURCES += ../../common/midi/midi_null.c ../../common/sound/sound_in_null.c ../../common/sound/sound_out_sdl2.c
 endif
 
-liblark_la_CFLAGS = -I../../../src -I../../common/midi -I../../common/sound -I../../common/uart
+liblark_la_CFLAGS = $(SDL_CFLAGS) -I../../../src -I../../common/midi -I../../common/sound -I../../common/uart
 liblark_la_LIBADD = @LIBS@
 
 if OS_WINDOWS

--- a/podules/morley_uap/src/Makefile.am
+++ b/podules/morley_uap/src/Makefile.am
@@ -32,7 +32,7 @@ amrefresh:
 
 libmorley_uap_la_SOURCES = morley_uap.c ../../common/joystick/joystick_sdl2.c ../../common/adc/d7002c.c ../../common/misc/6522.c
 
-libmorley_uap_la_CFLAGS = -I../../../src -I../../common/adc -I../../common/joystick -I../../common/misc $(shell sdl2-config --cflags)
+libmorley_uap_la_CFLAGS = -I../../../src -I../../common/adc -I../../common/joystick -I../../common/misc $(SDL_CFLAGS)
 libmorley_uap_la_LIBADD = @LIBS@
 
 endif

--- a/podules/oak_scsi/src/Makefile.am
+++ b/podules/oak_scsi/src/Makefile.am
@@ -42,7 +42,7 @@ if OS_MACOSX
 liboak_scsi_la_SOURCES += ../../common/cdrom/cdrom-osx-ioctl.c
 endif
 
-liboak_scsi_la_CFLAGS = -I../../../src -I../../common/cdrom -I../../common/eeprom -I../../common/sound -I../../common/scsi
+liboak_scsi_la_CFLAGS = $(SDL_CFLAGS) -I../../../src -I../../common/cdrom -I../../common/eeprom -I../../common/sound -I../../common/scsi
 liboak_scsi_la_LIBADD = @LIBS@
 
 endif

--- a/podules/ultimatecdrom/src/Makefile.am
+++ b/podules/ultimatecdrom/src/Makefile.am
@@ -42,7 +42,7 @@ if OS_MACOSX
 libultimatecdrom_la_SOURCES += ../../common/cdrom/cdrom-osx-ioctl.c
 endif
 
-libultimatecdrom_la_CFLAGS = -I../../../src -I../../common/cdrom -I../../common/sound
+libultimatecdrom_la_CFLAGS = $(SDL_CFLAGS) -I../../../src -I../../common/cdrom -I../../common/sound
 libultimatecdrom_la_LIBADD = @LIBS@
 
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,8 +36,8 @@ arculator_SOURCES = 82c711.c 82c711_fdc.c arm.c bmu.c cmos.c colourcard.c config
  video_sdl2.c wd1770.c wx-app.cc wx-config.cc wx-config_sel.cc wx-hd_conf.cc wx-console.cc wx-hd_new.cc \
  wx-joystick-config.cc wx-main.cc wx-podule-config.cc wx-resources.cc wx-sdl2-joystick.c
 
-arculator_CFLAGS = $(subst -fpermissive,,$(shell $(WX_CONFIG_PATH) --cxxflags) $(shell sdl2-config --cflags))
-arculator_CXXFLAGS = $(shell $(WX_CONFIG_PATH) --cxxflags) $(shell sdl2-config --cflags)
+arculator_CFLAGS = $(subst -fpermissive,,$(shell $(WX_CONFIG_PATH) --cxxflags)) $(SDL_CFLAGS)
+arculator_CXXFLAGS = $(shell $(WX_CONFIG_PATH) --cxxflags) $(SDL_CFLAGS)
 arculator_LDADD = @LIBS@
 
 if OS_WINDOWS


### PR DESCRIPTION
configure checks for SDL2, so the build system already has the SDL_CFLAGS set.

It's pointless to call sdl2-config each time, and also triggers warnings in at least
recent autotools.
