### PR TITLE
Add emulation support for 4MB ROMs

### DIFF
--- a/src/mem.c
+++ b/src/mem.c
@@ -65,7 +65,7 @@ void initmem(int memsize)
 	rpclog("initmem %i\n", memsize);
 	realmemsize=memsize;
 	ram=(uint32_t *)malloc(memsize*1024);
-	rom=(uint32_t *)malloc(0x200000);
+	rom=(uint32_t *)malloc(0x400000);
 	rom_arcrom = malloc(0x10000);
 	rom_5th_column = (uint8_t *)malloc(0x20000);
 	for (c=0;c<0x4000;c++) memstat[c]=0;


### PR DESCRIPTION
Trying to load a 4MB ROM normally makes Arculator crash. This change expands the ROM buffer and maps it so that 4MB ROMs may be tested.

This is useful for testing custom RISC OS 3.1 images (e.g. the Stardot unofficial RISC OS 3.20).

Rebase of previous patch on top of Arculator 2.2 code.