### PR TITLE
Don't play any disc noise when disc noise is "disabled"

### DIFF
--- a/src/sound_sdl2.c
+++ b/src/sound_sdl2.c
@@ -69,6 +69,9 @@ void sound_givebuffer(int16_t *buf)
 
 void sound_givebufferdd(int16_t *buf)
 {
+	if (disc_noise_gain == DISC_NOISE_DISABLED)
+		return;
+
 	/*If we're already sufficiently ahead of the audio device then drop this buffer rather than
 	  allowing the queued audio to build up indefinitely*/
 	if (SDL_AudioStreamAvailable(ddnoise_stream) > MAX_DDNOISE_STREAM_SIZE)


### PR DESCRIPTION
It seems that when the user selects "Disabled" for the disc noise volume (Menu->Disc >Disc drive noise->Disabled), Arculator internally sets the disc noise gain to a certain constant, `DISC_NOISE_DISABLED` (with the value of +9999). With the old OpenAL code, [Arculator checked for this special constant and, if it was there, returned without giving any sound data to OpenAL](https://github.com/sarah-walker-pcem/arculator/blob/55f29f8d2e8c4032646f3aa2e88d7481244724cc/src/soundopenal.c#L192-L193). The code to do this was inadvertently dropped when the sound system changed from OpenAL to SDL, meaning that when the disc noise is set to "Disabled", Arculator interprets the gain level as +9999, amplifying and distorting the drive noise to the point where it's just white noise at maximum volume, instead of playing silence as it should.

Although this PR fixes the issue in a manner that's closest to the way it worked under OpenAL, I'm a little uncomfortable with this fix because it means that `disc_noise_gain` is used in two different routines for different purposes. `sound_givebufferdd` appears to be intended for a "canonical" disc noise sound, whereas `sound_givebuffer` is what actually [mixes the disc noise buffer into the output stream and attenuates the volume using the `disc_noise_gain` variable](https://github.com/sarah-walker-pcem/arculator/blob/52d64c09361eb4edcb582380ce5d6ae77f91f8c7/src/sound_sdl2.c#L62). An alternative method of doing this patch would be to keep `sound_givebufferdd` providing a "canonical" drive sound while modifying `sound_givebuffer` to avoid mixing in the disc noise sound.

I've tested both methods and they both seem to work fine, but I chose to submit this method as it's the most similar to the method used in the code previously. I am happy to force-push the alternate method to this PR if wanted.

Fixes #38.