### PR TITLE
Improved detection of external libraries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,16 @@ if test "$wxWin" != 1; then
       ])
 fi
 
+case "$host" in
+    *-*-cygwin* | *-*-mingw32*)
+       ;;
+    *)
+       AC_PATH_XTRA
+       AS_IF([test "X$no_x" = "Xyes"],
+         [AC_MSG_ERROR([Could not find X11])])
+       ;;
+esac
+
 AC_CHECK_LIB([pthread], [pthread_create])
 
 build_macosx="no"
@@ -103,7 +113,7 @@ esac
 
 CFLAGS="$CFLAGS_BUILD $CFLAGS_RELEASE $CFLAGS"
 CXXFLAGS="$CFLAGS_BUILD $CFLAGS_RELEASE $CXXFLAGS"
-LIBS="$LIBS $WX_LIBS $SDL_LIBS"
+LIBS="$LIBS $WX_LIBS $SDL_LIBS $X_LIBS"
 
 AM_CONDITIONAL(OS_LINUX, [test "$build_linux" = "yes"])
 AM_CONDITIONAL(OS_WINDOWS, [test "$build_win" = "yes"])

--- a/mac-setup
+++ b/mac-setup
@@ -66,35 +66,22 @@ check_arch
 # If configured so, install brew based automake, autoconf and libtool:
 if [ "${use_brew_automake}" == "no" ];
 then
-    brew uninstall automake autoconf libtool xquartz
+    brew uninstall automake autoconf libtool
 else
     if [ $force_reinstall -eq 1 ];
     then
-        brew reinstall automake autoconf libtool xquartz
+        brew reinstall automake autoconf libtool
     else
-        brew install automake autoconf libtool xquartz
+        brew install automake autoconf libtool
     fi
 fi
 
 # Install build dependecies:
 if [ $force_reinstall -eq 1 ];
 then
-    brew reinstall wxwidgets sdl2
+    brew reinstall wxwidgets sdl2 xquartz
 else
-    brew install wxwidgets sdl2
-fi
-
-# We need SDL2 in the default path:
-echo 
-echo Checking if SDL2 is in the clang default path, if not I will need admin privileges to create the symlink there
-echo This operation may require sudo privileges, so it may request for a password.
-echo
-if [ ! -L /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/SDL2 ];
-then
-  sudo ln -s ${brew_prefix}/sdl2/*/include/SDL2 /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/SDL2
-else
-  sudo unlink /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/SDL2
-  sudo ln -s ${brew_prefix}/sdl2/*/include/SDL2 /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/SDL2
+    brew install wxwidgets sdl2 xquartz
 fi
 
 # If configured so, pull down and compile automake, autoconf and libtool:
@@ -186,30 +173,6 @@ check_link "depcomp"
 check_link "install-sh"
 check_link "missing"
 
-# We need X11 in the default path so:
-echo Checking if X11 is in the clang default path, if not I will need admin privileges to create the symlink there
-
-if [ ! -L /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/X11 ];
-then
-  sudo ln -s /opt/X11/include/X11 /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/X11
-  rval=$?
-  if [ ! $rval -eq 0 ];
-  then
-    ln -s /opt/X11/include/X11 /usr/local/include/X11
-  fi
-  sudo ln -s /opt/X11/lib/ /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/*/lib/x11
-else
-  sudo unlink /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/X11
-  sudo unlink /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/*/lib/x11
-  sudo ln -s /opt/X11/include/X11 /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/X11
-  rval=$?
-  if [ ! $rval -eq 0 ];
-  then
-    ln -s /opt/X11/include/X11 /usr/local/include/X11
-  fi
-  sudo ln -s /opt/X11/lib/ /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/*/lib/x11  
-fi
-
 echo Dependecies installed.
 
 echo
@@ -225,8 +188,7 @@ autoconf
 automake --add-missing --force-missing
 
 # Run configure to configure build:
-full_path=$(echo ${brew_prefix}/sdl2/*)
-./configure --with-sdl-prefix=${full_path}
+./configure
 
 # Clean up possible spurious side effect of configure:
 if [ -d ./arculator ];

--- a/podules/common/joystick/joystick_sdl2.c
+++ b/podules/common/joystick/joystick_sdl2.c
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include "joystick_api.h"
 #include "podule_api.h"
 

--- a/podules/common/sound/sound_out_sdl2.c
+++ b/podules/common/sound/sound_out_sdl2.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include "sound_out.h"
 
 typedef struct sdl_sound_t

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,9 +20,8 @@ endif
 amrefresh:
 
 # Special wxWidgets files
-WINDRES = $(shell $(WX_CONFIG_PATH) --rescomp)
 wx.res: wx.rc
-	$(WINDRES) -i wx.rc --input-format=rc -o wx.res -O coff
+	$(WX_RESCOMP) -i wx.rc --input-format=rc -o wx.res -O coff
 
 wx-resources.cc : arculator.xrc
 	-wxrc -c arculator.xrc -o wx-resources.cc
@@ -36,8 +35,8 @@ arculator_SOURCES = 82c711.c 82c711_fdc.c arm.c bmu.c cmos.c colourcard.c config
  video_sdl2.c wd1770.c wx-app.cc wx-config.cc wx-config_sel.cc wx-hd_conf.cc wx-console.cc wx-hd_new.cc \
  wx-joystick-config.cc wx-main.cc wx-podule-config.cc wx-resources.cc wx-sdl2-joystick.c
 
-arculator_CFLAGS = $(subst -fpermissive,,$(shell $(WX_CONFIG_PATH) --cxxflags)) $(SDL_CFLAGS)
-arculator_CXXFLAGS = $(shell $(WX_CONFIG_PATH) --cxxflags) $(SDL_CFLAGS)
+arculator_CFLAGS = $(WX_CFLAGS) $(SDL_CFLAGS) $(X_CFLAGS)
+arculator_CXXFLAGS = $(WX_CXXFLAGS) $(SDL_CFLAGS) $(X_CFLAGS)
 arculator_LDADD = @LIBS@
 
 if OS_WINDOWS

--- a/src/input_sdl2.c
+++ b/src/input_sdl2.c
@@ -1,6 +1,6 @@
 /*Arculator 2.2 by Sarah Walker
   SDL2 input handling*/
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <string.h>
 #include "arc.h"
 #include "plat_input.h"

--- a/src/keyboard_sdl.h
+++ b/src/keyboard_sdl.h
@@ -1,4 +1,4 @@
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #define KEY_ESC               SDL_SCANCODE_ESCAPE     /* keyboard scan codes  */
 #define KEY_1                 SDL_SCANCODE_1

--- a/src/sound_sdl2.c
+++ b/src/sound_sdl2.c
@@ -1,4 +1,4 @@
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include "plat_sound.h"
 #include "arc.h"
 #include "disc.h"

--- a/src/video_sdl2.c
+++ b/src/video_sdl2.c
@@ -1,6 +1,6 @@
 /*Arculator 2.2 by Sarah Walker
   SDL2 video handling*/
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #if WIN32
 #define BITMAP __win_bitmap

--- a/src/wx-app.cc
+++ b/src/wx-app.cc
@@ -2,7 +2,7 @@
   wxApp implementation
   Menus are also handled here*/
 #include <sstream>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #ifdef _WIN32
 #define BITMAP WINDOWS_BITMAP

--- a/src/wx-main.cc
+++ b/src/wx-main.cc
@@ -1,7 +1,7 @@
 /*Arculator 2.1 by Sarah Walker
   Main function*/
 #include "wx-app.h"
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <wx/filename.h>
 #include "wx-config_sel.h"
 

--- a/src/wx-sdl2-joystick.c
+++ b/src/wx-sdl2-joystick.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <math.h>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include "arc.h"
 #include "joystick.h"
 #include "plat_joystick.h"


### PR DESCRIPTION
This avoids needing to modify Xcode when building on Mac OS X, and should also help on other platforms where the required libraries are installed in non-default locations.