### PR TITLE
Add native macOS build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,38 @@
 .vscode
+.DS_Store
 
+# Autotools output
+autom4te.cache/
+config.log
+config.status
+configure~
+*~
+libtool
+**/Makefile
+**/Makefile.in
+/m4/libtool.m4
+/m4/lt*.m4
+
+# Compiler output
+.dirstamp
+**/.deps/
+**/.libs/
+*.o
+*.lo
+*.la
+*.dylib
+/arculator
+/src/arculator
+/src/wx-resources.cc
+
+# Runtime files
+/arc.cfg
+/arclog.txt
+/*_log.txt
+/cmos/*.bin
+/configs/*.cfg
+/modules.dmp
+/roms/**/*.[Rr][Oo][Mm]
+
+# Local wxWidgets source archives and trees
+/wxWidgets-*

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,2 +1,3 @@
 SUBDIRS = src podules/aeh50/src podules/aeh54/src podules/aka05/src podules/aka10/src podules/aka12/src podules/aka16/src podules/aka31/src podules/designit_e200/src podules/lark/src podules/midimax/src podules/morley_uap/src podules/oak_scsi/src podules/pccard/src podules/ultimatecdrom/src
 
+ACLOCAL_AMFLAGS = -I m4

--- a/README
+++ b/README
@@ -1,0 +1,28 @@
+Arculator
+~~~~~~~~~
+
+Arculator is an Acorn Archimedes emulator for Windows, Linux and macOS.
+See readme.txt for configuration and usage information.
+
+
+Building on macOS
+~~~~~~~~~~~~~~~~~
+
+The macOS build requires Homebrew and the Xcode Command Line Tools. From a
+checkout of this repository, run:
+
+    ./mac-setup
+    make -j"$(sysctl -n hw.logicalcpu)"
+
+mac-setup installs the required Homebrew packages, refreshes the build files
+and configures Arculator to use its native wxWidgets main window. It supports
+both Apple Silicon and Intel Macs. Pass "force" as the first argument to
+reinstall the Homebrew dependencies, or pass additional configure options
+after it. For example:
+
+    ./mac-setup --enable-debug
+
+Place the required RISC OS ROM images in the appropriate directories under
+roms, then run Arculator from the repository root:
+
+    ./arculator

--- a/configure.ac
+++ b/configure.ac
@@ -5,10 +5,20 @@ AC_PREREQ([2.69])
 AC_INIT([Arculator],[v2.2],[Sarah Walker <b-em@bbcmicro.com>],[arculator])
 
 AC_CANONICAL_HOST
+AC_CONFIG_MACRO_DIRS([m4])
 
 AM_INIT_AUTOMAKE
 AC_PROG_CC
 AC_PROG_CXX
+
+# Autoconf 2.72 and later may select C23 automatically. Arculator still uses
+# pre-C23 function declarations, so default to the last compatible standard
+# unless the caller selected one explicitly.
+case " $CFLAGS " in
+   *" -std="*) ;;
+   *) CFLAGS="$CFLAGS -std=gnu17" ;;
+esac
+
 AM_PROG_CC_C_O
 AC_CACHE_VAL(lt_cv_deplibs_check_method,
     [lt_cv_deplibs_check_method=pass_all])
@@ -46,7 +56,7 @@ if test "$enable_podules" != "no"; then
       SO_EXT=.so
    fi
    AC_SUBST(SO_EXT, "$SO_EXT")
-   CFLAGS_BUILD="-DSO_EXT=\\\"$SO_EXT\\\""
+   CFLAGS_BUILD="$CFLAGS_BUILD -DSO_EXT=\\\"$SO_EXT\\\""
 
    AC_MSG_RESULT([yes ($SO_EXT)])
 else
@@ -55,14 +65,17 @@ fi
 
 AC_MSG_CHECKING([whether to use wxwidgets for main window])
 AC_ARG_ENABLE(wx_main_window,
-          AS_HELP_STRING([--enable-wx-main-window],[build for wx main window]))
+          AS_HELP_STRING([--enable-wx-main-window],[build for wx main window (default on macOS)]),
+          [],
+          [case "$host" in
+              *-*-darwin*) enable_wx_main_window=yes ;;
+           esac])
 if test "$enable_wx_main_window" = "yes"; then
    AC_MSG_RESULT([yes])
    CFLAGS_UI_WX=" -DUI_WX"
 else
    AC_MSG_RESULT([no])
 fi
-AM_CONDITIONAL(RELEASE_BUILD, [test "$enable_release_build" = "yes"])
 
 AC_MSG_CHECKING([for libz])
 AC_CHECK_LIB(z, inflateEnd, [], \
@@ -91,7 +104,7 @@ if test "$wxWin" != 1; then
 fi
 
 case "$host" in
-    *-*-cygwin* | *-*-mingw32*)
+    *-*-cygwin* | *-*-mingw32* | *-*-darwin*)
        ;;
     *)
        AC_PATH_XTRA
@@ -138,11 +151,9 @@ AM_CONDITIONAL(OS_WINDOWS, [test "$build_win" = "yes"])
 AM_CONDITIONAL(OS_OTHER, [test "$build_other" = "yes"])
 AM_CONDITIONAL(OS_MACOSX, [test "$build_macosx" = "yes"])
 
-AM_CONDITIONAL(BUILD_PODULES, [test "$enable_podules" = "yes"])
+AM_CONDITIONAL(BUILD_PODULES, [test "$enable_podules" != "no"])
 AM_CONDITIONAL(UI_WX, [test "$enable_wx_main_window" = "yes"])
 
 AC_CONFIG_FILES([Makefile src/Makefile])
-AC_OUTPUT
-
 AC_CONFIG_FILES([podules/aeh50/src/Makefile podules/aeh54/src/Makefile podules/aka05/src/Makefile podules/aka10/src/Makefile podules/aka12/src/Makefile podules/aka16/src/Makefile podules/aka31/src/Makefile podules/designit_e200/src/Makefile podules/lark/src/Makefile podules/midimax/src/Makefile podules/morley_uap/src/Makefile podules/oak_scsi/src/Makefile podules/pccard/src/Makefile podules/ultimatecdrom/src/Makefile])
 AC_OUTPUT

--- a/m4/wxwin.m4
+++ b/m4/wxwin.m4
@@ -1,0 +1,1024 @@
+dnl ---------------------------------------------------------------------------
+dnl Author:          wxWidgets development team,
+dnl                  Francesco Montorsi,
+dnl                  Bob McCown (Mac-testing)
+dnl Creation date:   24/11/2001
+dnl ---------------------------------------------------------------------------
+
+dnl Increment this when changing this file.
+# serial 42
+
+dnl ===========================================================================
+dnl Table of Contents of this macro file:
+dnl -------------------------------------
+dnl
+dnl SECTION A: wxWidgets main macros
+dnl  - WX_CONFIG_OPTIONS
+dnl  - WX_CONFIG_CHECK
+dnl  - WXRC_CHECK
+dnl  - WX_STANDARD_OPTIONS
+dnl  - WX_CONVERT_STANDARD_OPTIONS_TO_WXCONFIG_FLAGS
+dnl  - WX_DETECT_STANDARD_OPTION_VALUES
+dnl
+dnl SECTION B: wxWidgets-related utilities
+dnl  - WX_LIKE_LIBNAME
+dnl  - WX_ARG_ENABLE_YESNOAUTO
+dnl  - WX_ARG_WITH_YESNOAUTO
+dnl
+dnl SECTION C: messages to the user
+dnl  - WX_STANDARD_OPTIONS_SUMMARY_MSG
+dnl  - WX_STANDARD_OPTIONS_SUMMARY_MSG_BEGIN
+dnl  - WX_STANDARD_OPTIONS_SUMMARY_MSG_END
+dnl  - WX_BOOLOPT_SUMMARY
+dnl
+dnl The special "WX_DEBUG_CONFIGURE" variable can be set to 1 to enable extra
+dnl debug output on stdout from these macros.
+dnl ===========================================================================
+
+
+dnl ---------------------------------------------------------------------------
+dnl Macros for wxWidgets detection. Typically used in configure.ac as:
+dnl
+dnl     AC_ARG_ENABLE(...)
+dnl     AC_ARG_WITH(...)
+dnl        ...
+dnl     WX_CONFIG_OPTIONS
+dnl        ...
+dnl        ...
+dnl     WX_CONFIG_CHECK([2.6.0], [wxWin=1])
+dnl     if test "$wxWin" != 1; then
+dnl        AC_MSG_ERROR([
+dnl                wxWidgets must be installed on your system
+dnl                but wx-config script couldn't be found.
+dnl
+dnl                Please check that wx-config is in path, the directory
+dnl                where wxWidgets libraries are installed (returned by
+dnl                'wx-config --libs' command) is in LD_LIBRARY_PATH or
+dnl                equivalent variable and wxWidgets version is 2.3.4 or above.
+dnl        ])
+dnl     fi
+dnl     CPPFLAGS="$CPPFLAGS $WX_CPPFLAGS"
+dnl     CXXFLAGS="$CXXFLAGS $WX_CXXFLAGS_ONLY"
+dnl     CFLAGS="$CFLAGS $WX_CFLAGS_ONLY"
+dnl
+dnl     LIBS="$LIBS $WX_LIBS"
+dnl
+dnl If you want to support standard --enable-debug/shared options, you
+dnl may do the following:
+dnl
+dnl     ...
+dnl     AC_CANONICAL_TARGET
+dnl
+dnl     # define configure options
+dnl     WX_CONFIG_OPTIONS
+dnl     WX_STANDARD_OPTIONS([debug,shared,toolkit,wxshared])
+dnl
+dnl     # basic configure checks
+dnl     ...
+dnl
+dnl     # we want to always have DEBUG==WX_DEBUG
+dnl     WX_DEBUG=$DEBUG
+dnl
+dnl     WX_CONVERT_STANDARD_OPTIONS_TO_WXCONFIG_FLAGS
+dnl     WX_CONFIG_CHECK([2.8.0], [wxWin=1],,[html,core,net,base],[$WXCONFIG_FLAGS])
+dnl     WX_DETECT_STANDARD_OPTION_VALUES
+dnl
+dnl     # write the output files
+dnl     AC_CONFIG_FILES([Makefile ...])
+dnl     AC_OUTPUT
+dnl
+dnl     # optional: just to show a message to the user
+dnl     WX_STANDARD_OPTIONS_SUMMARY_MSG
+dnl
+dnl ---------------------------------------------------------------------------
+
+
+dnl ---------------------------------------------------------------------------
+dnl WX_CONFIG_OPTIONS
+dnl
+dnl adds support for --wx-prefix, --wx-exec-prefix, --with-wxdir and
+dnl --wx-config command line options
+dnl ---------------------------------------------------------------------------
+
+AC_DEFUN([WX_CONFIG_OPTIONS],
+[
+    AC_ARG_WITH(wxdir,
+                [  --with-wxdir=PATH       Use uninstalled version of wxWidgets in PATH],
+                [ wx_config_name="$withval/wx-config"
+                  wx_config_args="--inplace"])
+    AC_ARG_WITH(wx-config,
+                [  --with-wx-config=CONFIG wx-config script to use (optional)],
+                wx_config_name="$withval" )
+    AC_ARG_WITH(wx-prefix,
+                [  --with-wx-prefix=PREFIX Prefix where wxWidgets is installed (optional)],
+                wx_config_prefix="$withval", wx_config_prefix="")
+    AC_ARG_WITH(wx-exec-prefix,
+                [  --with-wx-exec-prefix=PREFIX
+                          Exec prefix where wxWidgets is installed (optional)],
+                wx_config_exec_prefix="$withval", wx_config_exec_prefix="")
+])
+
+dnl Helper macro for checking if wx version is at least $1.$2.$3, set's
+dnl wx_ver_ok=yes if it is:
+AC_DEFUN([_WX_PRIVATE_CHECK_VERSION],
+[
+    wx_ver_ok=""
+    if test "x$WX_VERSION" != x ; then
+      if test $wx_config_major_version -gt $1; then
+        wx_ver_ok=yes
+      else
+        if test $wx_config_major_version -eq $1; then
+           if test $wx_config_minor_version -gt $2; then
+              wx_ver_ok=yes
+           else
+              if test $wx_config_minor_version -eq $2; then
+                 if test $wx_config_micro_version -ge $3; then
+                    wx_ver_ok=yes
+                 fi
+              fi
+           fi
+        fi
+      fi
+    fi
+])
+
+dnl ---------------------------------------------------------------------------
+dnl WX_CONFIG_CHECK(VERSION, [ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND
+dnl                  [, WX-LIBS [, ADDITIONAL-WX-CONFIG-FLAGS
+dnl                  [, WX-OPTIONAL-LIBS]]]]])
+dnl
+dnl Test for wxWidgets, and define WX_C*FLAGS, WX_LIBS and WX_LIBS_STATIC
+dnl (the latter is for static linking against wxWidgets). Set WX_CONFIG_NAME
+dnl environment variable to override the default name of the wx-config script
+dnl to use. Set WX_CONFIG_PATH to specify the full path to wx-config - in this
+dnl case the macro won't even waste time on tests for its existence.
+dnl
+dnl Optional WX-LIBS argument contains comma- or space-separated list of
+dnl wxWidgets libraries to link against. If it is not specified then WX_LIBS
+dnl and WX_LIBS_STATIC will contain flags to link with all of the core
+dnl wxWidgets libraries.
+dnl
+dnl Optional ADDITIONAL-WX-CONFIG-FLAGS argument is appended to wx-config
+dnl invocation command in present. It can be used to fine-tune lookup of
+dnl best wxWidgets build available.
+dnl
+dnl Optional WX-OPTIONAL-LIBS argument contains comma- or space-separated list
+dnl of wxWidgets libraries to link against if they are available.
+dnl WX-OPTIONAL-LIBS is supported on version 2.9.0 and later.
+dnl
+dnl Example use:
+dnl   WX_CONFIG_CHECK([2.6.0], [wxWin=1], [wxWin=0], [html,core,net], [--debug])
+dnl ---------------------------------------------------------------------------
+
+dnl
+dnl Get the cflags and libraries from the wx-config script
+dnl
+AC_DEFUN([WX_CONFIG_CHECK],
+[
+  dnl do we have wx-config name: it can be wx-config or wxd-config or ...
+  if test x${WX_CONFIG_NAME+set} != xset ; then
+     WX_CONFIG_NAME=wx-config
+  fi
+
+  if test "x$wx_config_name" != x ; then
+     WX_CONFIG_NAME="$wx_config_name"
+  fi
+
+  dnl deal with optional prefixes
+  if test x$wx_config_exec_prefix != x ; then
+     wx_config_args="$wx_config_args --exec-prefix=$wx_config_exec_prefix"
+     WX_LOOKUP_PATH="$wx_config_exec_prefix/bin"
+  fi
+  if test x$wx_config_prefix != x ; then
+     wx_config_args="$wx_config_args --prefix=$wx_config_prefix"
+     WX_LOOKUP_PATH="$WX_LOOKUP_PATH:$wx_config_prefix/bin"
+  fi
+  if test "$cross_compiling" = "yes"; then
+     wx_config_args="$wx_config_args --host=$host_alias"
+  fi
+
+  dnl don't search the PATH if WX_CONFIG_NAME is absolute filename
+  if test -x "$WX_CONFIG_NAME" ; then
+     AC_MSG_CHECKING(for wx-config)
+     WX_CONFIG_PATH="$WX_CONFIG_NAME"
+     AC_MSG_RESULT($WX_CONFIG_PATH)
+  else
+     AC_PATH_PROG(WX_CONFIG_PATH, $WX_CONFIG_NAME, no, "$WX_LOOKUP_PATH:$PATH")
+  fi
+
+  if test "$WX_CONFIG_PATH" != "no" ; then
+    WX_VERSION=""
+
+    min_wx_version=ifelse([$1], ,2.2.1,$1)
+    if test -z "$5" ; then
+      AC_MSG_CHECKING([for wxWidgets version >= $min_wx_version])
+    else
+      AC_MSG_CHECKING([for wxWidgets version >= $min_wx_version ($5)])
+    fi
+
+    dnl don't add the libraries (4th argument) to this variable as this would
+    dnl result in an error when it's used with --version below
+    WX_CONFIG_WITH_ARGS="$WX_CONFIG_PATH $wx_config_args $5"
+
+    WX_VERSION=`$WX_CONFIG_WITH_ARGS --version 2>/dev/null`
+    wx_config_major_version=`echo $WX_VERSION | \
+           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\1/'`
+    wx_config_minor_version=`echo $WX_VERSION | \
+           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\2/'`
+    wx_config_micro_version=`echo $WX_VERSION | \
+           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\3/'`
+
+    wx_requested_major_version=`echo $min_wx_version | \
+           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\1/'`
+    wx_requested_minor_version=`echo $min_wx_version | \
+           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\2/'`
+    wx_requested_micro_version=`echo $min_wx_version | \
+           sed 's/\([[0-9]]*\).\([[0-9]]*\).\([[0-9]]*\)/\3/'`
+
+    _WX_PRIVATE_CHECK_VERSION([$wx_requested_major_version],
+                              [$wx_requested_minor_version],
+                              [$wx_requested_micro_version])
+
+    if test -n "$wx_ver_ok"; then
+      AC_MSG_RESULT(yes (version $WX_VERSION))
+
+      wx_optional_libs=""
+      _WX_PRIVATE_CHECK_VERSION(2,9,0)
+      if test -n "$wx_ver_ok" -a -n "$6"; then
+        wx_optional_libs="--optional-libs $6"
+      fi
+      WX_LIBS=`$WX_CONFIG_WITH_ARGS --libs $4 $wx_optional_libs`
+
+      dnl is this even still appropriate?  --static is a real option now
+      dnl and WX_CONFIG_WITH_ARGS is likely to contain it if that is
+      dnl what the user actually wants, making this redundant at best.
+      dnl For now keep it in case anyone actually used it in the past.
+      AC_MSG_CHECKING([for wxWidgets static library])
+      WX_LIBS_STATIC=`$WX_CONFIG_WITH_ARGS --static --libs $4 $wx_optional_libs 2>/dev/null`
+      if test "x$WX_LIBS_STATIC" = "x"; then
+        AC_MSG_RESULT(no)
+      else
+        AC_MSG_RESULT(yes)
+      fi
+
+      dnl starting with version 2.2.6 wx-config has --cppflags argument
+      wx_has_cppflags=""
+      if test $wx_config_major_version -gt 2; then
+        wx_has_cppflags=yes
+      else
+        if test $wx_config_major_version -eq 2; then
+           if test $wx_config_minor_version -gt 2; then
+              wx_has_cppflags=yes
+           else
+              if test $wx_config_minor_version -eq 2; then
+                 if test $wx_config_micro_version -ge 6; then
+                    wx_has_cppflags=yes
+                 fi
+              fi
+           fi
+        fi
+      fi
+
+      dnl starting with version 2.7.0 wx-config has --rescomp option
+      wx_has_rescomp=""
+      if test $wx_config_major_version -gt 2; then
+        wx_has_rescomp=yes
+      else
+        if test $wx_config_major_version -eq 2; then
+           if test $wx_config_minor_version -ge 7; then
+              wx_has_rescomp=yes
+           fi
+        fi
+      fi
+      if test "x$wx_has_rescomp" = x ; then
+         dnl cannot give any useful info for resource compiler
+         WX_RESCOMP=
+      else
+         WX_RESCOMP=`$WX_CONFIG_WITH_ARGS --rescomp`
+      fi
+
+      if test "x$wx_has_cppflags" = x ; then
+         dnl no choice but to define all flags like CFLAGS
+         WX_CFLAGS=`$WX_CONFIG_WITH_ARGS --cflags $4`
+         WX_CPPFLAGS=$WX_CFLAGS
+         WX_CXXFLAGS=$WX_CFLAGS
+
+         WX_CFLAGS_ONLY=$WX_CFLAGS
+         WX_CXXFLAGS_ONLY=$WX_CFLAGS
+      else
+         dnl we have CPPFLAGS included in CFLAGS included in CXXFLAGS
+         WX_CPPFLAGS=`$WX_CONFIG_WITH_ARGS --cppflags $4`
+         WX_CXXFLAGS=`$WX_CONFIG_WITH_ARGS --cxxflags $4`
+         WX_CFLAGS=`$WX_CONFIG_WITH_ARGS --cflags $4`
+
+         WX_CFLAGS_ONLY=`echo $WX_CFLAGS | sed "s@^$WX_CPPFLAGS *@@"`
+         WX_CXXFLAGS_ONLY=`echo $WX_CXXFLAGS | sed "s@^$WX_CFLAGS *@@"`
+      fi
+
+      ifelse([$2], , :, [$2])
+
+    else
+
+       if test "x$WX_VERSION" = x; then
+          dnl no wx-config at all
+          AC_MSG_RESULT(no)
+       else
+          AC_MSG_RESULT(no (version $WX_VERSION is not new enough))
+       fi
+
+       WX_CFLAGS=""
+       WX_CPPFLAGS=""
+       WX_CXXFLAGS=""
+       WX_LIBS=""
+       WX_LIBS_STATIC=""
+       WX_RESCOMP=""
+
+       if test ! -z "$5"; then
+
+          wx_error_message="
+    The configuration you asked for $PACKAGE_NAME requires a wxWidgets
+    build with the following settings:
+        $5
+    but such build is not available.
+
+    To see the wxWidgets builds available on this system, please use
+    'wx-config --list' command. To use the default build, returned by
+    'wx-config --selected-config', use the options with their 'auto'
+    default values."
+
+       fi
+
+       wx_error_message="
+    The requested wxWidgets build couldn't be found.
+    $wx_error_message
+
+    If you still get this error, then check that 'wx-config' is
+    in path, the directory where wxWidgets libraries are installed
+    (returned by 'wx-config --libs' command) is in LD_LIBRARY_PATH
+    or equivalent variable and wxWidgets version is $1 or above."
+
+       ifelse([$3], , AC_MSG_ERROR([$wx_error_message]), [$3])
+
+    fi
+  else
+
+    WX_CFLAGS=""
+    WX_CPPFLAGS=""
+    WX_CXXFLAGS=""
+    WX_LIBS=""
+    WX_LIBS_STATIC=""
+    WX_RESCOMP=""
+
+    ifelse([$3], , :, [$3])
+
+  fi
+
+  AC_SUBST(WX_CPPFLAGS)
+  AC_SUBST(WX_CFLAGS)
+  AC_SUBST(WX_CXXFLAGS)
+  AC_SUBST(WX_CFLAGS_ONLY)
+  AC_SUBST(WX_CXXFLAGS_ONLY)
+  AC_SUBST(WX_LIBS)
+  AC_SUBST(WX_LIBS_STATIC)
+  AC_SUBST(WX_VERSION)
+  AC_SUBST(WX_RESCOMP)
+
+  dnl need to export also WX_VERSION_MINOR and WX_VERSION_MAJOR symbols
+  dnl to support wxpresets bakefiles (we export also WX_VERSION_MICRO for completeness):
+  WX_VERSION_MAJOR="$wx_config_major_version"
+  WX_VERSION_MINOR="$wx_config_minor_version"
+  WX_VERSION_MICRO="$wx_config_micro_version"
+  AC_SUBST(WX_VERSION_MAJOR)
+  AC_SUBST(WX_VERSION_MINOR)
+  AC_SUBST(WX_VERSION_MICRO)
+])
+
+dnl ---------------------------------------------------------------------------
+dnl Get information on the wxrc program for making C++, Python and xrs
+dnl resource files.
+dnl
+dnl     AC_ARG_ENABLE(...)
+dnl     AC_ARG_WITH(...)
+dnl        ...
+dnl     WX_CONFIG_OPTIONS
+dnl        ...
+dnl     WX_CONFIG_CHECK(2.6.0, wxWin=1)
+dnl     if test "$wxWin" != 1; then
+dnl        AC_MSG_ERROR([
+dnl                wxWidgets must be installed on your system
+dnl                but wx-config script couldn't be found.
+dnl
+dnl                Please check that wx-config is in path, the directory
+dnl                where wxWidgets libraries are installed (returned by
+dnl                'wx-config --libs' command) is in LD_LIBRARY_PATH or
+dnl                equivalent variable and wxWidgets version is 2.6.0 or above.
+dnl        ])
+dnl     fi
+dnl
+dnl     WXRC_CHECK([HAVE_WXRC=1], [HAVE_WXRC=0])
+dnl     if test "x$HAVE_WXRC" != x1; then
+dnl         AC_MSG_ERROR([
+dnl                The wxrc program was not installed or not found.
+dnl
+dnl                Please check the wxWidgets installation.
+dnl         ])
+dnl     fi
+dnl
+dnl     CPPFLAGS="$CPPFLAGS $WX_CPPFLAGS"
+dnl     CXXFLAGS="$CXXFLAGS $WX_CXXFLAGS_ONLY"
+dnl     CFLAGS="$CFLAGS $WX_CFLAGS_ONLY"
+dnl
+dnl     LDFLAGS="$LDFLAGS $WX_LIBS"
+dnl ---------------------------------------------------------------------------
+
+dnl ---------------------------------------------------------------------------
+dnl WXRC_CHECK([ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND]])
+dnl
+dnl Test for wxWidgets' wxrc program for creating either C++, Python or XRS
+dnl resources.  The variable WXRC will be set and substituted in the configure
+dnl script and Makefiles.
+dnl
+dnl Example use:
+dnl   WXRC_CHECK([wxrc=1], [wxrc=0])
+dnl ---------------------------------------------------------------------------
+
+dnl
+dnl wxrc program from the wx-config script
+dnl
+AC_DEFUN([WXRC_CHECK],
+[
+  AC_ARG_VAR([WXRC], [Path to wxWidget's wxrc resource compiler])
+
+  if test "x$WX_CONFIG_NAME" = x; then
+    AC_MSG_ERROR([The wxrc tests must run after wxWidgets test.])
+  else
+
+    AC_MSG_CHECKING([for wxrc])
+
+    if test "x$WXRC" = x ; then
+      dnl wx-config --utility is a new addition to wxWidgets:
+      _WX_PRIVATE_CHECK_VERSION(2,5,3)
+      if test -n "$wx_ver_ok"; then
+        WXRC=`$WX_CONFIG_WITH_ARGS --utility=wxrc`
+      fi
+    fi
+
+    if test "x$WXRC" = x ; then
+      AC_MSG_RESULT([not found])
+      ifelse([$2], , :, [$2])
+    else
+      AC_MSG_RESULT([$WXRC])
+      ifelse([$1], , :, [$1])
+    fi
+
+    AC_SUBST(WXRC)
+  fi
+])
+
+dnl ---------------------------------------------------------------------------
+dnl WX_LIKE_LIBNAME([output-var] [prefix], [name])
+dnl
+dnl Sets the "output-var" variable to the name of a library named with same
+dnl wxWidgets rule.
+dnl E.g. for output-var=='lib', name=='test', prefix='mine', sets
+dnl      the $lib variable to:
+dnl          'mine_gtk2ud_test-2.8'
+dnl      if WX_PORT=gtk2, WX_DEBUG=1 and WX_RELEASE=28
+dnl ---------------------------------------------------------------------------
+AC_DEFUN([WX_LIKE_LIBNAME],
+    [
+        wx_temp="$2""_""$WX_PORT""u"
+
+        dnl add the "d" suffix if necessary
+        if test "$WX_DEBUG" = "1"; then
+            wx_temp="$wx_temp""d"
+        fi
+
+        dnl complete the name of the lib
+        wx_temp="$wx_temp""_""$3""-$WX_VERSION_MAJOR.$WX_VERSION_MINOR"
+
+        dnl save it in the user's variable
+        $1=$wx_temp
+    ])
+
+dnl ---------------------------------------------------------------------------
+dnl WX_ARG_ENABLE_YESNOAUTO/WX_ARG_WITH_YESNOAUTO
+dnl
+dnl Two little custom macros which define the ENABLE/WITH configure arguments.
+dnl Macro arguments:
+dnl $1 = the name of the --enable / --with  feature
+dnl $2 = the name of the variable associated
+dnl $3 = the description of that feature
+dnl $4 = the default value for that feature
+dnl $5 = additional action to do in case option is given with "yes" value
+dnl ---------------------------------------------------------------------------
+AC_DEFUN([WX_ARG_ENABLE_YESNOAUTO],
+         [AC_ARG_ENABLE($1,
+            AS_HELP_STRING([--enable-$1],[$3 (default is $4)]),
+            [], [enableval="$4"])
+
+            dnl Show a message to the user about this option
+            AC_MSG_CHECKING([for the --enable-$1 option])
+            if test "$enableval" = "yes" ; then
+                AC_MSG_RESULT([yes])
+                $2=1
+                $5
+            elif test "$enableval" = "no" ; then
+                AC_MSG_RESULT([no])
+                $2=0
+            elif test "$enableval" = "auto" ; then
+                AC_MSG_RESULT([will be automatically detected])
+                $2=""
+            else
+                AC_MSG_ERROR([
+    Unrecognized option value (allowed values: yes, no, auto)
+                ])
+            fi
+         ])
+
+AC_DEFUN([WX_ARG_WITH_YESNOAUTO],
+         [AC_ARG_WITH($1,
+            AS_HELP_STRING([--with-$1],[$3 (default is $4)]),
+            [], [withval="$4"])
+
+            dnl Show a message to the user about this option
+            AC_MSG_CHECKING([for the --with-$1 option])
+            if test "$withval" = "yes" ; then
+                AC_MSG_RESULT([yes])
+                $2=1
+                $5
+            dnl NB: by default we don't allow --with-$1=no option
+            dnl     since it does not make much sense !
+            elif test "$6" = "1" -a "$withval" = "no" ; then
+                AC_MSG_RESULT([no])
+                $2=0
+            elif test "$withval" = "auto" ; then
+                AC_MSG_RESULT([will be automatically detected])
+                $2=""
+            else
+                AC_MSG_ERROR([
+    Unrecognized option value (allowed values: yes, auto)
+                ])
+            fi
+         ])
+
+
+dnl ---------------------------------------------------------------------------
+dnl WX_STANDARD_OPTIONS([options-to-add])
+dnl
+dnl Adds to the configure script one or more of the following options:
+dnl   --enable-[debug|shared|wxshared|wxdebug]
+dnl   --with-[gtk|msw|x11|mac|dfb]
+dnl   --with-wxversion
+dnl Then checks for their presence and eventually set the DEBUG, SHARED,
+dnl PORT, WX_SHARED, WX_DEBUG, variables to one of the "yes", "no", "auto" values.
+dnl
+dnl Note that e.g. DEBUG != WX_DEBUG; the first is the value of the
+dnl --enable-debug option (in boolean format) while the second indicates
+dnl if wxWidgets was built in debug mode (and still is in boolean format).
+dnl ---------------------------------------------------------------------------
+AC_DEFUN([WX_STANDARD_OPTIONS],
+        [
+
+        dnl the following lines will expand to WX_ARG_ENABLE_YESNOAUTO calls if and only if
+        dnl the $1 argument contains respectively the debug or shared options.
+
+        dnl be careful here not to set debug flag if only "wxdebug" was specified
+        ifelse(regexp([$1], [\bdebug]), [-1],,
+               [WX_ARG_ENABLE_YESNOAUTO([debug], [DEBUG], [Build in debug mode], [auto])])
+
+        ifelse(regexp([$1], [\bshared]), [-1],,
+               [WX_ARG_ENABLE_YESNOAUTO([shared], [SHARED], [Build as shared library], [auto])])
+
+        dnl WX_ARG_WITH_YESNOAUTO cannot be used for --with-toolkit since it's an option
+        dnl which must be able to accept the auto|gtk2|msw|... values
+        ifelse(index([$1], [toolkit]), [-1],,
+               [
+                AC_ARG_WITH([toolkit],
+                            AS_HELP_STRING([--with-toolkit],[Build against a specific wxWidgets toolkit (default is auto)]),
+                            [], [withval="auto"])
+
+                dnl Show a message to the user about this option
+                AC_MSG_CHECKING([for the --with-toolkit option])
+                if test "$withval" = "auto" ; then
+                    AC_MSG_RESULT([will be automatically detected])
+                    TOOLKIT=""
+                else
+                    TOOLKIT="$withval"
+
+                    dnl PORT must be one of the allowed values
+                    if test "$TOOLKIT" != "gtk2" -a "$TOOLKIT" != "gtk3" -a \
+                            "$TOOLKIT" != "msw" -a \
+                            "$TOOLKIT" != "osx_carbon" -a "$TOOLKIT" != "osx_cocoa" -a \
+                            "$TOOLKIT" != "dfb" -a "$TOOLKIT" != "x11" -a "$TOOLKIT" != "base"; then
+                        AC_MSG_ERROR([
+    Unrecognized option value (allowed values: auto, gtk2, gtk3, msw, osx_carbon, osx_cocoa, dfb, x11, base)
+                        ])
+                    fi
+
+                    AC_MSG_RESULT([$TOOLKIT])
+                fi
+               ])
+
+        dnl ****** IMPORTANT *******
+        dnl   You can build your program in shared mode against a static build
+        dnl   of wxWidgets. Thus we have the following option which allows
+        dnl   these mixtures. E.g.
+        dnl
+        dnl      ./configure --disable-shared --with-wxshared
+        dnl
+        dnl   will build your library in static mode against the first available
+        dnl   shared build of wxWidgets.
+        dnl
+        dnl   Note that's not possible to do the viceversa:
+        dnl
+        dnl      ./configure --enable-shared --without-wxshared
+        dnl
+        dnl   Doing so you would try to build your library in shared mode against a static
+        dnl   build of wxWidgets. This is not possible (you would mix PIC and non PIC code) !
+        dnl   A check for this combination of options is in WX_DETECT_STANDARD_OPTION_VALUES
+        dnl   (where we know what 'auto' should be expanded to).
+        dnl ************************
+
+        ifelse(index([$1], [wxshared]), [-1],,
+               [
+                WX_ARG_WITH_YESNOAUTO(
+                    [wxshared], [WX_SHARED],
+                    [Force building against a shared build of wxWidgets, even if --disable-shared is given],
+                    [auto], [], [1])
+               ])
+
+        dnl Just like for SHARED and WX_SHARED it may happen that some adventurous
+        dnl peoples will want to mix a wxWidgets release build with a debug build of
+        dnl his app/lib. So, we have both DEBUG and WX_DEBUG variables.
+        ifelse(index([$1], [wxdebug]), [-1],,
+               [
+                WX_ARG_WITH_YESNOAUTO(
+                    [wxdebug], [WX_DEBUG],
+                    [Force building against a debug build of wxWidgets, even if --disable-debug is given],
+                    [auto], [], [1])
+               ])
+
+        dnl WX_ARG_WITH_YESNOAUTO cannot be used for --with-wxversion since it's an option
+        dnl which accepts the "auto|2.6|2.7|2.8|2.9|3.0" etc etc values
+        ifelse(index([$1], [wxversion]), [-1],,
+               [
+                AC_ARG_WITH([wxversion],
+                            AS_HELP_STRING([--with-wxversion],[Build against a specific version of wxWidgets (default is auto)]),
+                            [], [withval="auto"])
+
+                dnl Show a message to the user about this option
+                AC_MSG_CHECKING([for the --with-wxversion option])
+                if test "$withval" = "auto" ; then
+                    AC_MSG_RESULT([will be automatically detected])
+                    WX_RELEASE=""
+                else
+
+                    wx_requested_major_version=`echo $withval | \
+                        sed 's/\([[0-9]]*\).\([[0-9]]*\).*/\1/'`
+                    wx_requested_minor_version=`echo $withval | \
+                        sed 's/\([[0-9]]*\).\([[0-9]]*\).*/\2/'`
+
+                    dnl both vars above must be exactly 1 digit
+                    if test "${#wx_requested_major_version}" != "1" -o \
+                            "${#wx_requested_minor_version}" != "1" ; then
+                        AC_MSG_ERROR([
+    Unrecognized option value (allowed values: auto, 2.6, 2.7, 2.8, 2.9, 3.0)
+                        ])
+                    fi
+
+                    WX_RELEASE="$wx_requested_major_version"".""$wx_requested_minor_version"
+                    AC_MSG_RESULT([$WX_RELEASE])
+                fi
+               ])
+
+        if test "$WX_DEBUG_CONFIGURE" = "1"; then
+            echo "[[dbg]] DEBUG: $DEBUG, WX_DEBUG: $WX_DEBUG"
+            echo "[[dbg]] SHARED: $SHARED, WX_SHARED: $WX_SHARED"
+            echo "[[dbg]] TOOLKIT: $TOOLKIT, WX_TOOLKIT: $WX_TOOLKIT"
+            echo "[[dbg]] VERSION: $VERSION, WX_RELEASE: $WX_RELEASE"
+        fi
+    ])
+
+
+dnl ---------------------------------------------------------------------------
+dnl WX_CONVERT_STANDARD_OPTIONS_TO_WXCONFIG_FLAGS
+dnl
+dnl Sets the WXCONFIG_FLAGS string using the SHARED,DEBUG variable values
+dnl which were specified.
+dnl Thus this macro needs to be called only once all options have been set.
+dnl ---------------------------------------------------------------------------
+AC_DEFUN([WX_CONVERT_STANDARD_OPTIONS_TO_WXCONFIG_FLAGS],
+        [
+        if test "$WX_SHARED" = "1" ; then
+            WXCONFIG_FLAGS="--static=no "
+        elif test "$WX_SHARED" = "0" ; then
+            WXCONFIG_FLAGS="--static=yes "
+        fi
+
+        if test "$WX_DEBUG" = "1" ; then
+            WXCONFIG_FLAGS="$WXCONFIG_FLAGS""--debug=yes "
+        elif test "$WX_DEBUG" = "0" ; then
+            WXCONFIG_FLAGS="$WXCONFIG_FLAGS""--debug=no "
+        fi
+
+        if test -n "$TOOLKIT" ; then
+            WXCONFIG_FLAGS="$WXCONFIG_FLAGS""--toolkit=$TOOLKIT "
+        fi
+
+        if test -n "$WX_RELEASE" ; then
+            WXCONFIG_FLAGS="$WXCONFIG_FLAGS""--version=$WX_RELEASE "
+        fi
+
+        dnl strip out the last space of the string
+        WXCONFIG_FLAGS=${WXCONFIG_FLAGS% }
+
+        if test "$WX_DEBUG_CONFIGURE" = "1"; then
+            echo "[[dbg]] WXCONFIG_FLAGS: $WXCONFIG_FLAGS"
+        fi
+    ])
+
+
+dnl ---------------------------------------------------------------------------
+dnl _WX_SELECTEDCONFIG_CHECKFOR([RESULTVAR], [STRING], [MSG])
+dnl
+dnl Sets WX_$RESULTVAR to the value of $RESULTVAR if it's defined. Otherwise,
+dnl auto-detect the value by checking for the presence of STRING in
+dnl $WX_SELECTEDCONFIG (which is supposed to be set by caller) and set
+dnl WX_$RESULTVAR to either 0 or 1, also outputting "yes" or "no" after MSG.
+dnl ---------------------------------------------------------------------------
+AC_DEFUN([_WX_SELECTEDCONFIG_CHECKFOR],
+        [
+        if test -z "$$1" ; then
+
+            dnl The user does not have particular preferences for this option;
+            dnl so we will detect the wxWidgets relative build setting and use it
+            AC_MSG_CHECKING([$3])
+
+            dnl set WX_$1 variable to 1 if the $WX_SELECTEDCONFIG contains the $2
+            dnl string or to 0 otherwise.
+            dnl NOTE: 'expr match STRING REGEXP' cannot be used since on Mac it
+            dnl       doesn't work; we use 'expr STRING : REGEXP' instead
+            WX_$1=$(expr "$WX_SELECTEDCONFIG" : ".*$2.*")
+
+            if test "$WX_$1" != "0"; then
+                WX_$1=1
+                AC_MSG_RESULT([yes])
+            else
+                WX_$1=0
+                AC_MSG_RESULT([no])
+            fi
+        else
+
+            dnl Use the setting given by the user
+            WX_$1=$$1
+        fi
+    ])
+
+dnl ---------------------------------------------------------------------------
+dnl WX_DETECT_STANDARD_OPTION_VALUES
+dnl
+dnl Detects the values of the following variables:
+dnl - WX_RELEASE
+dnl - WX_DEBUG
+dnl - WX_SHARED    (and also WX_STATIC)
+dnl - WX_PORT
+dnl from the previously selected wxWidgets build; this macro in fact must be
+dnl called *after* calling the WX_CONFIG_CHECK macro.
+dnl
+dnl Note that the WX_VERSION_MAJOR, WX_VERSION_MINOR symbols are already set
+dnl by WX_CONFIG_CHECK macro
+dnl ---------------------------------------------------------------------------
+AC_DEFUN([WX_DETECT_STANDARD_OPTION_VALUES],
+        [
+        dnl IMPORTANT: WX_VERSION contains all three major.minor.micro digits,
+        dnl            while WX_RELEASE only the major.minor ones.
+        WX_RELEASE="$WX_VERSION_MAJOR""$WX_VERSION_MINOR"
+        if test $WX_RELEASE -lt 26 ; then
+
+            AC_MSG_ERROR([
+    Cannot detect the wxWidgets configuration for the selected wxWidgets build
+    since its version is $WX_VERSION < 2.6.0; please install a newer
+    version of wxWidgets.
+                         ])
+        fi
+
+        dnl The wx-config we are using understands the "--selected_config"
+        dnl option which returns an easy-parseable string !
+        WX_SELECTEDCONFIG=$($WX_CONFIG_WITH_ARGS --selected_config)
+
+        if test "$WX_DEBUG_CONFIGURE" = "1"; then
+            echo "[[dbg]] Using wx-config --selected-config"
+            echo "[[dbg]] WX_SELECTEDCONFIG: $WX_SELECTEDCONFIG"
+        fi
+
+        dnl we could test directly for WX_SHARED with a line like:
+        dnl    _WX_SELECTEDCONFIG_CHECKFOR([SHARED], [shared],
+        dnl                                [if wxWidgets was built in SHARED mode])
+        dnl but wx-config --selected-config DOES NOT outputs the 'shared'
+        dnl word when wx was built in shared mode; it rather outputs the
+        dnl 'static' word when built in static mode.
+        if test "$WX_SHARED" = "1"; then
+            STATIC=0
+        elif test "$WX_SHARED" = "0"; then
+            STATIC=1
+        fi
+
+        dnl Now set the WX_DEBUG, WX_STATIC variables
+        _WX_SELECTEDCONFIG_CHECKFOR([DEBUG], [debug],
+                                    [if wxWidgets was built in DEBUG mode])
+        _WX_SELECTEDCONFIG_CHECKFOR([STATIC], [static],
+                                    [if wxWidgets was built in STATIC mode])
+
+        dnl init WX_SHARED from WX_STATIC
+        if test "$WX_STATIC" != "0"; then
+            WX_SHARED=0
+        else
+            WX_SHARED=1
+        fi
+
+        AC_SUBST(WX_DEBUG)
+        AC_SUBST(WX_SHARED)
+
+        dnl detect the WX_PORT to use
+        if test -z "$TOOLKIT" ; then
+
+            dnl The user does not have particular preferences for this option;
+            dnl so we will detect the wxWidgets relative build setting and use it
+            AC_MSG_CHECKING([which wxWidgets toolkit was selected])
+
+            WX_GTKPORT2=$(expr "$WX_SELECTEDCONFIG" : ".*gtk2.*")
+            WX_GTKPORT3=$(expr "$WX_SELECTEDCONFIG" : ".*gtk3.*")
+            WX_MSWPORT=$(expr "$WX_SELECTEDCONFIG" : ".*msw.*")
+            WX_OSXCOCOAPORT=$(expr "$WX_SELECTEDCONFIG" : ".*osx_cocoa.*")
+            WX_OSXCARBONPORT=$(expr "$WX_SELECTEDCONFIG" : ".*osx_carbon.*")
+            WX_X11PORT=$(expr "$WX_SELECTEDCONFIG" : ".*x11.*")
+            WX_DFBPORT=$(expr "$WX_SELECTEDCONFIG" : ".*dfb.*")
+            WX_BASEPORT=$(expr "$WX_SELECTEDCONFIG" : ".*base.*")
+
+            WX_PORT="unknown"
+            if test "$WX_GTKPORT2" != "0"; then WX_PORT="gtk2"; fi
+            if test "$WX_GTKPORT3" != "0"; then WX_PORT="gtk3"; fi
+            if test "$WX_MSWPORT" != "0"; then WX_PORT="msw"; fi
+            if test "$WX_OSXCOCOAPORT" != "0"; then WX_PORT="osx_cocoa"; fi
+            if test "$WX_OSXCARBONPORT" != "0"; then WX_PORT="osx_carbon"; fi
+            if test "$WX_X11PORT" != "0"; then WX_PORT="x11"; fi
+            if test "$WX_DFBPORT" != "0"; then WX_PORT="dfb"; fi
+            if test "$WX_BASEPORT" != "0"; then WX_PORT="base"; fi
+
+            dnl NOTE: backward-compatible check for wx2.8; in wx2.9 the mac
+            dnl       ports are called 'osx_cocoa' and 'osx_carbon' (see above)
+            WX_MACPORT=$(expr "$WX_SELECTEDCONFIG" : ".*mac.*")
+            if test "$WX_MACPORT" != "0"; then WX_PORT="mac"; fi
+
+            dnl check at least one of the WX_*PORT has been set !
+
+            if test "$WX_PORT" = "unknown" ; then
+                AC_MSG_ERROR([
+        Cannot detect the currently installed wxWidgets port !
+        Please check your 'wx-config --cxxflags'...
+                            ])
+            fi
+
+            AC_MSG_RESULT([$WX_PORT])
+        else
+            dnl Use the setting given by the user
+            WX_PORT=$TOOLKIT
+        fi
+
+        AC_SUBST(WX_PORT)
+
+        if test "$WX_DEBUG_CONFIGURE" = "1"; then
+            echo "[[dbg]] Values of all WX_* options after final detection:"
+            echo "[[dbg]] WX_DEBUG: $WX_DEBUG"
+            echo "[[dbg]] WX_SHARED: $WX_SHARED"
+            echo "[[dbg]] WX_RELEASE: $WX_RELEASE"
+            echo "[[dbg]] WX_PORT: $WX_PORT"
+        fi
+
+        dnl Avoid problem described in the WX_STANDARD_OPTIONS which happens when
+        dnl the user gives the options:
+        dnl      ./configure --enable-shared --without-wxshared
+        dnl or just do
+        dnl      ./configure --enable-shared
+        dnl but there is only a static build of wxWidgets available.
+        if test "$WX_SHARED" = "0" -a "$SHARED" = "1"; then
+            AC_MSG_ERROR([
+    Cannot build shared library against a static build of wxWidgets !
+    This error happens because the wxWidgets build which was selected
+    has been detected as static while you asked to build $PACKAGE_NAME
+    as shared library and this is not possible.
+    Use the '--disable-shared' option to build $PACKAGE_NAME
+    as static library or '--with-wxshared' to use wxWidgets as shared library.
+                         ])
+        fi
+
+        dnl now we can finally update the options to their final values if they
+        dnl were not already set
+        if test -z "$SHARED" ; then
+            SHARED=$WX_SHARED
+        fi
+        if test -z "$TOOLKIT" ; then
+            TOOLKIT=$WX_PORT
+        fi
+
+        dnl respect the DEBUG variable adding the optimize/debug flags and also
+        dnl define a BUILD variable in case the user wants to use it
+        dnl
+        dnl NOTE: the CXXFLAGS are merged together with the CPPFLAGS so we
+        dnl       don't need to set them, too
+        if test "$DEBUG" = "1"; then
+            BUILD="debug"
+            CXXFLAGS="$CXXFLAGS -g -O0"
+            CFLAGS="$CFLAGS -g -O0"
+        elif test "$DEBUG" = "0"; then
+            BUILD="release"
+            CXXFLAGS="$CXXFLAGS -O2"
+            CFLAGS="$CFLAGS -O2"
+        fi
+    ])
+
+dnl ---------------------------------------------------------------------------
+dnl WX_BOOLOPT_SUMMARY([name of the boolean variable to show summary for],
+dnl                   [what to print when var is 1],
+dnl                   [what to print when var is 0])
+dnl
+dnl Prints $2 when variable $1 == 1 and prints $3 when variable $1 == 0.
+dnl This macro mainly exists just to make configure.ac scripts more readable.
+dnl
+dnl NOTE: you need to use the [" my message"] syntax for 2nd and 3rd arguments
+dnl       if you want that m4 avoid to throw away the spaces prefixed to the
+dnl       argument value.
+dnl ---------------------------------------------------------------------------
+AC_DEFUN([WX_BOOLOPT_SUMMARY],
+        [
+        if test "x$$1" = "x1" ; then
+            echo $2
+        elif test "x$$1" = "x0" ; then
+            echo $3
+        else
+            echo "$1 is $$1"
+        fi
+    ])
+
+dnl ---------------------------------------------------------------------------
+dnl WX_STANDARD_OPTIONS_SUMMARY_MSG
+dnl
+dnl Shows a summary message to the user about the WX_* variable contents.
+dnl This macro is used typically at the end of the configure script.
+dnl ---------------------------------------------------------------------------
+AC_DEFUN([WX_STANDARD_OPTIONS_SUMMARY_MSG],
+        [
+        echo
+        echo "  The wxWidgets build which will be used by $PACKAGE_NAME $PACKAGE_VERSION"
+        echo "  has the following settings:"
+        WX_BOOLOPT_SUMMARY([WX_DEBUG],   ["  - DEBUG build"],  ["  - RELEASE build"])
+        WX_BOOLOPT_SUMMARY([WX_SHARED],  ["  - SHARED mode"],  ["  - STATIC mode"])
+        echo "  - VERSION: $WX_VERSION"
+        echo "  - PORT: $WX_PORT"
+    ])
+
+
+dnl ---------------------------------------------------------------------------
+dnl WX_STANDARD_OPTIONS_SUMMARY_MSG_BEGIN, WX_STANDARD_OPTIONS_SUMMARY_MSG_END
+dnl
+dnl Like WX_STANDARD_OPTIONS_SUMMARY_MSG macro but these two macros also gives info
+dnl about the configuration of the package which used the wxpresets.
+dnl
+dnl Typical usage:
+dnl    WX_STANDARD_OPTIONS_SUMMARY_MSG_BEGIN
+dnl    echo "   - Package setting 1: $SETTING1"
+dnl    echo "   - Package setting 2: $SETTING1"
+dnl    ...
+dnl    WX_STANDARD_OPTIONS_SUMMARY_MSG_END
+dnl
+dnl ---------------------------------------------------------------------------
+AC_DEFUN([WX_STANDARD_OPTIONS_SUMMARY_MSG_BEGIN],
+        [
+        echo
+        echo " ----------------------------------------------------------------"
+        echo "  Configuration for $PACKAGE_NAME $PACKAGE_VERSION successfully completed."
+        echo "  Summary of main configuration settings for $PACKAGE_NAME:"
+        WX_BOOLOPT_SUMMARY([DEBUG], ["  - DEBUG build"], ["  - RELEASE build"])
+        WX_BOOLOPT_SUMMARY([SHARED], ["  - SHARED mode"], ["  - STATIC mode"])
+    ])
+
+AC_DEFUN([WX_STANDARD_OPTIONS_SUMMARY_MSG_END],
+        [
+        WX_STANDARD_OPTIONS_SUMMARY_MSG
+        echo
+        echo "  Now, just run make."
+        echo " ----------------------------------------------------------------"
+        echo
+    ])
+
+
+dnl ---------------------------------------------------------------------------
+dnl Deprecated macro wrappers
+dnl ---------------------------------------------------------------------------
+
+AC_DEFUN([AM_OPTIONS_WXCONFIG], [WX_CONFIG_OPTIONS])
+AC_DEFUN([AM_PATH_WXCONFIG], [
+    WX_CONFIG_CHECK([$1],[$2],[$3],[$4],[$5])
+])
+AC_DEFUN([AM_PATH_WXRC], [WXRC_CHECK([$1],[$2])])

--- a/mac-setup
+++ b/mac-setup
@@ -48,5 +48,10 @@ autoreconf --force --install
 # work remains on the main thread.
 ./configure "$@"
 
+# Changing the selected window backend alters both the executable's object list
+# and compilation flags, which Make does not detect by itself. Clean any prior
+# build so objects configured for a different backend cannot be reused.
+make clean
+
 echo
 echo "Configuration complete. Run 'make' to build Arculator."

--- a/mac-setup
+++ b/mac-setup
@@ -1,202 +1,52 @@
 #!/bin/bash
 
-# Author: Paolo Fabio Zaino
-# Please report any issue you encounter with this script to the author.
+# Original script by Paolo Fabio Zaino.
 
-# Check CLI parameters:
-if [ "$1" == "force" ];
-then 
-    force_reinstall=1
+set -euo pipefail
+
+if [ "$(uname -s)" != "Darwin" ]; then
+	echo "mac-setup must be run on macOS." >&2
+	exit 1
+fi
+
+force_reinstall=false
+if [ "${1:-}" = "force" ]; then
+	force_reinstall=true
+	shift
+fi
+
+if ! command -v brew >/dev/null 2>&1; then
+	echo "Homebrew is required. Install it from https://brew.sh and run mac-setup again." >&2
+	exit 1
+fi
+
+packages=(autoconf automake libtool pkg-config sdl2 wxwidgets)
+
+if $force_reinstall; then
+	brew reinstall "${packages[@]}"
 else
-    force_reinstall=0
+	brew install "${packages[@]}"
 fi
 
-# Configure build requirements:
-# (if you have no homebrew installed then set the following to 1, otherwise keep it to 2!)
-use_config=2
+# The repository contains Linux-specific links to Automake's helper files.
+# Replace them with copies from the installed Automake before configuring.
+automake_libdir=$(automake --print-libdir)
+for helper in INSTALL compile config.guess config.sub depcomp install-sh missing; do
+	if [ ! -f "$automake_libdir/$helper" ]; then
+		echo "Unable to find $helper in $automake_libdir." >&2
+		exit 1
+	fi
+	rm -f "$helper"
+	cp "$automake_libdir/$helper" "$helper"
+done
 
-if [ $use_config -eq 1 ];
-then
-    am_ver="1.15"
-    lt_ver="2.4.6"
-    ac_ver="2.69"
-    use_brew_automake="no"
-else
-    am_ver="1.16"
-    lt_ver="2.4.7"
-    ac_ver="2.71"
-    use_brew_automake="yes"
-fi
+# wxWidgets 3.3 no longer installs its Autoconf macros, so the required macro
+# is kept in m4/wxwin.m4 and can be used by a normal autoreconf invocation.
+autoreconf --force --install
 
-# support functions:
-
-function check_arch() {
-    arch="$(uname -m)"
-
-    case "${arch}" in
-        arm64)  brew_prefix="/opt/homebrew/Cellar"
-                ;;
-
-            *)  brew_prefix="/usr/local/Cellar"
-                ;;
-    esac
-}
-
-function check_link() {
-    f="$1"
-    if [ -L ${f} ]; then
-        unlink ./${f}
-    fi
-    if [ "${use_brew_automake}" == "no" ];
-    then
-        ln -s /usr/local/share/automake-${am_ver}/${f} ./${f}
-    else
-        ln -s ${brew_prefix}/automake/${am_ver}.*/share/automake-${am_ver}/${f} ./${f}
-        #ln -s ${brew_prefix}/share/automake-${am_ver}/${f} ./${f}
-    fi
-}
-
-############
-# setup:
-############
-
-# Check system Architecture:
-check_arch
-
-# If configured so, install brew based automake, autoconf and libtool:
-if [ "${use_brew_automake}" == "no" ];
-then
-    brew uninstall automake autoconf libtool
-else
-    if [ $force_reinstall -eq 1 ];
-    then
-        brew reinstall automake autoconf libtool
-    else
-        brew install automake autoconf libtool
-    fi
-fi
-
-# Install build dependecies:
-if [ $force_reinstall -eq 1 ];
-then
-    brew reinstall wxwidgets sdl2 xquartz
-else
-    brew install wxwidgets sdl2 xquartz
-fi
-
-# If configured so, pull down and compile automake, autoconf and libtool:
-if [ "$use_brew_automake" == "no" ];
-then
-  pushd ../
-
-    # add automake
-    am_size=0
-    [ -f ./automake-${am_ver}.tar.gz ] && am_size=$(ls -l ./automake-${am_ver}.tar.gz | awk '{print  $5}')
-
-    if [ ! -f ./automake-${am_ver}.tar.gz ] || [ $am_size -lt 250 ];
-    then
-      [ -f ./automake-${am_ver}.tar.gz ] && rm ./automake-${am_ver}.tar.gz
-      curl -O -L http://ftpmirror.gnu.org/automake/automake-${am_ver}.tar.gz
-
-      tar -xzf automake-${am_ver}.tar.gz
-
-      pushd automake-${am_ver}
-
-        ./configure
-
-        make -j4
-
-        sudo make install
-
-      popd
-
-    fi
-
-    # Add libtool
-    lt_size=0
-    [ -f ./libtool-${lt_ver}.tar.gz ] && lt_size=$(ls -l ./libtool-${lt_ver}.tar.gz | awk '{print  $5}')
-
-    if [ ! -f ./libtool-${lt_ver}.tar.gz ] || [ $lt_size -lt 360 ];
-    then
-      [ -f ./libtool-${lt_ver}.tar.gz ] && rm ./libtool-${lt_ver}.tar.gz
-
-      curl -O -L http://ftpmirror.gnu.org/libtool/libtool-${lt_ver}.tar.gz
-
-      tar -xzf libtool-${lt_ver}.tar.gz
-
-      pushd libtool-${lt_ver}
-
-        ./configure
-
-        make
-
-        sudo make install
-
-      popd
-
-    fi
-
-    # Add autoconf
-    ac_size=0
-    [ -f ./autoconf-${ac_ver}.tar.gz ] && ac_size=$(ls -l ./autoconf-${ac_ver}.tar.gz | awk '{print  $5}')
-
-    if [ ! -f ./autoconf-${ac_ver}.tar.gz ] || [ $ac_size -lt 360 ];
-    then
-      [ -f ./autoconf-${ac_ver}.tar.gz ] && rm ./autoconf-${ac_ver}.tar.gz
-
-      curl -O -L http://ftpmirror.gnu.org/autoconf/autoconf-${ac_ver}.tar.gz
-
-      tar -xzf autoconf-${ac_ver}.tar.gz
-
-      pushd autoconf-${ac_ver}
-
-          ./configure
-
-          make
-
-          sudo make install
-
-      popd
-
-    fi
-
-  popd
-
-fi
-
-# Check all the automake symlinks:
-check_link "INSTALL"
-check_link "compile"
-check_link "config.guess"
-check_link "config.sub"
-check_link "depcomp"
-check_link "install-sh"
-check_link "missing"
-
-echo Dependecies installed.
+# The configure default uses the native wxWidgets window on macOS so Cocoa UI
+# work remains on the main thread.
+./configure "$@"
 
 echo
-
-# Reconfigure Project:
-aclocal -I ${brew_prefix}/wxwidgets/*/share/wx/*/aclocal/ -I ${brew_prefix}/sdl2/*/share/aclocal/ -I /opt/X11/share/aclocal/
-autoconf
-automake --add-missing --force-missing
-autoreconf --force --install -I ${brew_prefix}/wxwidgets/*/share/wx/*/aclocal/ -I ${brew_prefix}/sdl2/*/share/aclocal/ -I /opt/X11/share/aclocal/
-autoupdate
-aclocal -I ${brew_prefix}/wxwidgets/*/share/wx/*/aclocal/ -I ${brew_prefix}/sdl2/*/share/aclocal/ -I /opt/X11/share/aclocal/
-autoconf
-automake --add-missing --force-missing
-
-# Run configure to configure build:
-./configure
-
-# Clean up possible spurious side effect of configure:
-if [ -d ./arculator ];
-then
-    rm -rf ./arculator
-fi
-
-# We're done!
-echo Done! 
-
-exit $?
+echo "Configuration complete. Run 'make' to build Arculator."

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,6 +48,12 @@ else
 arculator_SOURCES += input_sdl2.c video_sdl2.c wx-sdl2.c
 endif
 arculator_SOURCES += hostfs-unix.c podules-unix.c
-arculator_LDADD += -ldl -lX11
+arculator_LDADD += -ldl
+if OS_LINUX
+arculator_LDADD += -lX11
+endif
+if OS_OTHER
+arculator_LDADD += -lX11
+endif
 endif
 

--- a/src/video_wx.c
+++ b/src/video_wx.c
@@ -1,6 +1,7 @@
 /*Arculator 2.2 by Sarah Walker
   SDL2 video handling*/
 #include <stdio.h>
+#include <string.h>
 #include "arc.h"
 #include "plat_video.h"
 #include "vidc.h"

--- a/src/wx-app.cc
+++ b/src/wx-app.cc
@@ -58,6 +58,9 @@ App::App()
 
 bool App::OnInit()
 {
+#ifdef __APPLE__
+	SetExitOnFrameDelete(true);
+#endif
 	wxImage::AddHandler( new wxPNGHandler );
 	wxXmlResource::Get()->InitAllHandlers();
 	InitXmlResource();
@@ -82,6 +85,7 @@ bool App::OnInit()
 
 static void *main_frame = NULL;
 void *main_menu = NULL;
+static bool quit_after_stop = false;
 
 static wxMenuItem *find_item(int id)
 {
@@ -142,6 +146,11 @@ void Frame::OnStopEmulationEvent(wxCommandEvent &event)
 	arc_stop_main_thread();
 
 	debug_end();
+	if (quit_after_stop)
+	{
+		Quit(0);
+		return;
+	}
 
 	if (!ShowConfigSelection())
 		arc_start_main_thread(this, this->menu);
@@ -212,7 +221,7 @@ void Frame::UpdateMenu()
 	else
 		item = find_item(XRCID("IDM_BLACK_NORMAL"));
 	item->Check(true);
-	sprintf(menuitem, "IDM_VIDEO_SCALE[%d]", video_scale);
+	snprintf(menuitem, sizeof(menuitem), "IDM_VIDEO_SCALE[%d]", video_scale);
 	item = find_item(XRCID(menuitem));
 	item->Check(true);
 
@@ -267,11 +276,16 @@ extern "C" void arc_send_close();
 
 void OnMenuCommandCommon( wxCommandEvent &event, wxWindow *parent)
 {
-	if (event.GetId() == XRCID("IDM_FILE_EXIT"))
+	if (event.GetId() == XRCID("IDM_FILE_EXIT")
+#ifdef __APPLE__
+			|| event.GetId() == wxID_EXIT
+#endif
+			)
 	{
 #ifdef _WIN32
 		arc_send_close();
 #else
+		quit_after_stop = true;
 		arc_stop_emulation();
 #endif
 	}
@@ -410,7 +424,11 @@ void OnMenuCommandCommon( wxCommandEvent &event, wxWindow *parent)
 			firstfull = 0;
 
 			arc_pause_main_thread();
+#ifdef __APPLE__
+			wxMessageBox("Use CMD + BACKSPACE to return to windowed mode", "Arculator", wxOK | wxCENTRE | wxSTAY_ON_TOP);
+#else
 			wxMessageBox("Use CTRL + END to return to windowed mode", "Arculator", wxOK | wxCENTRE | wxSTAY_ON_TOP);
+#endif
 			arc_resume_main_thread();
 		}
 		arc_enter_fullscreen();
@@ -639,7 +657,7 @@ extern "C" void arc_print_error(const char *format, ...)
 	va_list ap;
 
 	va_start(ap, format);
-	vsprintf(buf, format, ap);
+	vsnprintf(buf, sizeof(buf), format, ap);
 	va_end(ap);
 
 	event->SetString(wxString(buf));

--- a/src/wx-main.cc
+++ b/src/wx-main.cc
@@ -7,7 +7,7 @@
 
 extern "C"
 {
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__APPLE__)
 	#include <X11/Xlib.h>
 #endif
 	#include "arc.h"
@@ -17,7 +17,7 @@ extern "C"
 
 int main(int argc, char **argv)
 {
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__APPLE__)
 	XInitThreads();
 #endif
 

--- a/src/wx-mainwindow.cc
+++ b/src/wx-mainwindow.cc
@@ -22,7 +22,6 @@ extern "C"
 	#include "video.h"
 }
 
-static int winsizex = 0, winsizey = 0;
 static int vidx = 0, vidy = 0;
 
 extern "C" BITMAP *wxbuffer;
@@ -60,6 +59,27 @@ typedef void (wxEvtHandler::*MyPlotEventFunction)(MyPlotEvent&);
     wx__DECLARE_EVT1(myEVT_PLOT, wxID_ANY, MyPlotEventHandler(func))
 
 wxDEFINE_EVENT(myEVT_PLOT, MyPlotEvent);
+
+class MyResizeEvent: public wxCommandEvent
+{
+public:
+	MyResizeEvent(int video_width, int video_height, int window_width, int window_height)
+		: wxCommandEvent(myEVT_RESIZE),
+		  video_width(video_width),
+		  video_height(video_height),
+		  window_width(window_width),
+		  window_height(window_height)
+	{
+	}
+
+	virtual wxEvent *Clone() const { return new MyResizeEvent(*this); }
+
+	int video_width, video_height;
+	int window_width, window_height;
+};
+
+wxDEFINE_EVENT(myEVT_RESIZE, MyResizeEvent);
+wxDEFINE_EVENT(myEVT_TITLE, wxThreadEvent);
 
 
 void MainCanvas::OnPaint(wxPaintEvent &event)
@@ -142,9 +162,20 @@ void MainCanvas::OnKeyDown(wxKeyEvent &event)
 	int kc = event.GetKeyCode();
 //	printf("keycode %i\n", kc);
 
+#ifdef __APPLE__
+	if ((kc == WXK_BACK || kc == WXK_DELETE) && event.CmdDown())
+#else
 	if (kc == WXK_END && event.GetModifiers() == wxMOD_CONTROL)
+#endif
 	{
 //		printf("CTRL+END\n");
+		if (fullscreen)
+		{
+			wxFrame *frame = wxDynamicCast(wxGetTopLevelParent(this), wxFrame);
+			if (frame)
+				frame->ShowFullScreen(false);
+			fullscreen = 0;
+		}
 		if (mousecapture)
 		{
 			mouse_capture_disable();
@@ -206,6 +237,8 @@ MainFrame::MainFrame(Frame *parent, const wxString& title, const wxPoint& pos, c
 {
 	canvas = new MainCanvas(this, "editor", wxDefaultPosition, wxDefaultSize);
 	SetMenuBar((wxMenuBar *)main_menu);
+	Bind(myEVT_RESIZE, &MainFrame::OnResize, this);
+	Bind(myEVT_TITLE, &MainFrame::OnTitle, this);
 }
 
 MainFrame::~MainFrame()
@@ -221,6 +254,19 @@ void MainFrame::OnClose(wxCloseEvent& event)
 void MainFrame::OnMenu(wxCommandEvent& event)
 {
 	OnMenuCommandCommon(event, this);
+}
+
+void MainFrame::OnResize(MyResizeEvent& event)
+{
+	vidx = event.video_width;
+	vidy = event.video_height;
+	if (!fullscreen)
+		SetClientSize(event.window_width, event.window_height);
+}
+
+void MainFrame::OnTitle(wxThreadEvent& event)
+{
+	SetLabel(event.GetString());
 }
 
 wxBEGIN_EVENT_TABLE(MainFrame, wxFrame)
@@ -294,10 +340,18 @@ extern "C" int arc_main_thread(void *p)
 		{
 			char s[80];
 
-			sprintf(s, "Arculator %s - %i%% - %s", VERSION_STRING, inssec, mousecapture ? "Press CTRL-END to release mouse" : "Click to capture mouse");
+#ifdef __APPLE__
+			snprintf(s, sizeof(s), "Arculator %s - %i%% - %s", VERSION_STRING, inssec, mousecapture ? "Press CMD-BACKSPACE to release mouse" : "Click to capture mouse");
+#else
+			snprintf(s, sizeof(s), "Arculator %s - %i%% - %s", VERSION_STRING, inssec, mousecapture ? "Press CTRL-END to release mouse" : "Click to capture mouse");
+#endif
 			vidc_framecount = 0;
 			if (!fullscreen)
-				arcFrame->SetLabel(s);
+			{
+				wxThreadEvent *event = new wxThreadEvent(myEVT_TITLE);
+				event->SetString(s);
+				wxQueueEvent(arcFrame, event);
+			}
 			updatemips=0;
 		}
 	}
@@ -309,12 +363,11 @@ extern "C" int arc_main_thread(void *p)
 
 extern "C" void updatewindowsize(int x, int y)
 {
-	arcFrame->SetClientSize(winsizex, winsizey);
-	vidx = x;
-	vidy = y;
-	winsizex = (x*(video_scale + 1)) / 2;
-	winsizey = (y*(video_scale + 1)) / 2;
-	/*win_doresize = 1;*/
+	int window_width = (x*(video_scale + 1)) / 2;
+	int window_height = (y*(video_scale + 1)) / 2;
+
+	MyResizeEvent *event = new MyResizeEvent(x, y, window_width, window_height);
+	wxQueueEvent(arcFrame, event);
 }
 
 extern "C" void arc_start_main_thread(void *wx_window, void *wx_menu)
@@ -434,6 +487,9 @@ extern "C" void arc_set_resizeable()
 
 extern "C" void arc_enter_fullscreen()
 {
+	fullscreen = 1;
+	arcFrame->ShowFullScreen(true);
+	arcFrame->GetCanvas()->SetFocus();
 }
 
 extern "C" void video_renderer_present(int src_x, int src_y, int src_w, int src_h, int dblscan)

--- a/src/wx-mainwindow.cc
+++ b/src/wx-mainwindow.cc
@@ -4,6 +4,9 @@
 #include <wx/wx.h>
 #include <wx/rawbmp.h>
 #endif
+#ifdef __APPLE__
+#include <wx/display.h>
+#endif
 
 #include <SDL.h>
 
@@ -170,12 +173,7 @@ void MainCanvas::OnKeyDown(wxKeyEvent &event)
 	{
 //		printf("CTRL+END\n");
 		if (fullscreen)
-		{
-			wxFrame *frame = wxDynamicCast(wxGetTopLevelParent(this), wxFrame);
-			if (frame)
-				frame->ShowFullScreen(false);
-			fullscreen = 0;
-		}
+			static_cast<MainFrame *>(wxGetTopLevelParent(this))->LeaveFullScreen();
 		if (mousecapture)
 		{
 			mouse_capture_disable();
@@ -233,7 +231,7 @@ wxEND_EVENT_TABLE()
 
 MainFrame::MainFrame(Frame *parent, const wxString& title, const wxPoint& pos, const wxSize& size)
 	: wxFrame(NULL, wxID_ANY, title, pos, size, wxDEFAULT_FRAME_STYLE | wxWANTS_CHARS),
-	  parent(parent)
+	  canvas(NULL), parent(parent), initial_size_set(false)
 {
 	canvas = new MainCanvas(this, "editor", wxDefaultPosition, wxDefaultSize);
 	SetMenuBar((wxMenuBar *)main_menu);
@@ -258,15 +256,68 @@ void MainFrame::OnMenu(wxCommandEvent& event)
 
 void MainFrame::OnResize(MyResizeEvent& event)
 {
+	// VIDC reports incomplete dimensions while the first mode is being set.
+	if (event.video_width <= 0 || event.video_height <= 0 ||
+	    event.window_width <= 0 || event.window_height <= 0)
+		return;
+
 	vidx = event.video_width;
 	vidy = event.video_height;
 	if (!fullscreen)
+	{
+#ifdef __APPLE__
+		// Cocoa can move the frame when its client size changes. Avoid repeated
+		// resizes and preserve the current position across genuine mode changes.
+		wxSize requested_size(event.window_width, event.window_height);
+		if (requested_size != last_window_size)
+		{
+			wxPoint window_position = GetPosition();
+			SetClientSize(requested_size);
+			last_window_size = requested_size;
+			if (initial_size_set)
+				Move(window_position);
+		}
+		if (!initial_size_set)
+		{
+			// Place the first usable mode in the centre of its current display.
+			int display_index = wxDisplay::GetFromWindow(this);
+			if (display_index == wxNOT_FOUND)
+				display_index = 0;
+			wxRect display_area = wxDisplay(display_index).GetClientArea();
+			Move(display_area.x + (display_area.width - event.window_width) / 2,
+			     display_area.y + (display_area.height - event.window_height) / 2);
+			initial_size_set = true;
+		}
+#else
 		SetClientSize(event.window_width, event.window_height);
+#endif
+	}
 }
 
 void MainFrame::OnTitle(wxThreadEvent& event)
 {
 	SetLabel(event.GetString());
+}
+
+void MainFrame::EnterFullScreen()
+{
+	if (fullscreen)
+		return;
+
+	windowed_rect = GetRect();
+	fullscreen = 1;
+	ShowFullScreen(true);
+	canvas->SetFocus();
+}
+
+void MainFrame::LeaveFullScreen()
+{
+	if (!fullscreen)
+		return;
+
+	ShowFullScreen(false);
+	fullscreen = 0;
+	SetSize(windowed_rect);
 }
 
 wxBEGIN_EVENT_TABLE(MainFrame, wxFrame)
@@ -487,9 +538,7 @@ extern "C" void arc_set_resizeable()
 
 extern "C" void arc_enter_fullscreen()
 {
-	fullscreen = 1;
-	arcFrame->ShowFullScreen(true);
-	arcFrame->GetCanvas()->SetFocus();
+	arcFrame->EnterFullScreen();
 }
 
 extern "C" void video_renderer_present(int src_x, int src_y, int src_w, int src_h, int dblscan)

--- a/src/wx-mainwindow.h
+++ b/src/wx-mainwindow.h
@@ -6,14 +6,17 @@ extern "C"
 
 class MyPlotEvent;
 wxDECLARE_EVENT(myEVT_PLOT, MyPlotEvent);
+class MyResizeEvent;
+wxDECLARE_EVENT(myEVT_RESIZE, MyResizeEvent);
+wxDECLARE_EVENT(myEVT_TITLE, wxThreadEvent);
 
 class MainCanvas: public wxWindow
 {
 public:
 	MainCanvas(wxWindow *parent, const wxString& title, const wxPoint& pos, const wxSize& size)
 	: wxWindow(parent, wxID_ANY, pos, size, wxDEFAULT_FRAME_STYLE | wxWANTS_CHARS),
-	  bmp(2048, 2048, 24),
-	  dx(0), dy(0), last_mouse_pos(0, 0)
+	  dx(0), dy(0), b(0),
+	  bmp(2048, 2048, 24), last_mouse_pos(0, 0)
 	{
 	}
 
@@ -90,6 +93,8 @@ public:
 private:
 	void OnClose(wxCloseEvent& event);
 	void OnMenu(wxCommandEvent& event);
+	void OnResize(MyResizeEvent& event);
+	void OnTitle(wxThreadEvent& event);
 
 	MainCanvas *canvas;
 	Frame *parent;

--- a/src/wx-mainwindow.h
+++ b/src/wx-mainwindow.h
@@ -85,6 +85,8 @@ public:
 	virtual ~MainFrame();
 
 	MainCanvas *GetCanvas() { return canvas; }
+	void EnterFullScreen();
+	void LeaveFullScreen();
 	void UpdateMenu()
 	{
 		parent->UpdateMenu();
@@ -98,6 +100,9 @@ private:
 
 	MainCanvas *canvas;
 	Frame *parent;
+	bool initial_size_set;
+	wxSize last_window_size;
+	wxRect windowed_rect;
 
 	wxDECLARE_EVENT_TABLE();
 };

--- a/src/wx-sdl2.c
+++ b/src/wx-sdl2.c
@@ -120,11 +120,21 @@ static int arc_main_thread(void *p)
 					break;
 				}
 			}
+#ifdef __APPLE__
+			if ((key[KEY_LWIN] || key[KEY_RWIN])
+			    && key[KEY_BACKSPACE]
+			    && !fullscreen && mousecapture)
+#else
 			if ((key[KEY_LCONTROL] || key[KEY_RCONTROL])
 			    && key[KEY_END]
 			    && !fullscreen && mousecapture)
+#endif
 			{
+#ifdef __APPLE__
+				rpclog("CMD-BACKSPACE pressed -- disabling mouse capture\n");
+#else
 				rpclog("CTRL-END pressed -- disabling mouse capture\n");
+#endif
 				sdl_disable_mouse_capture();
 			}
 		}
@@ -159,8 +169,13 @@ static int arc_main_thread(void *p)
 			sdl_enable_mouse_capture();
 			fullscreen = 1;
 		} else if (fullscreen && (
+#ifdef __APPLE__
+			/*Exit fullscreen with Cmd-Backspace*/
+			((key[KEY_LWIN] || key[KEY_RWIN]) && key[KEY_BACKSPACE])
+#else
 			/*Exit fullscreen with Ctrl-End*/
 			((key[KEY_LCONTROL] || key[KEY_RCONTROL]) && key[KEY_END])
+#endif
 			/*Toggle with RWIN-Enter*/
 			|| (key[KEY_RWIN] && key[KEY_ENTER])
 		))
@@ -208,7 +223,11 @@ static int arc_main_thread(void *p)
 		{
 			char s[80];
 
-			sprintf(s, "Arculator %s - %i%% - %s", VERSION_STRING, inssec, mousecapture ? "Press CTRL-END to release mouse" : "Click to capture mouse");
+#ifdef __APPLE__
+			snprintf(s, sizeof(s), "Arculator %s - %i%% - %s", VERSION_STRING, inssec, mousecapture ? "Press CMD-BACKSPACE to release mouse" : "Click to capture mouse");
+#else
+			snprintf(s, sizeof(s), "Arculator %s - %i%% - %s", VERSION_STRING, inssec, mousecapture ? "Press CTRL-END to release mouse" : "Click to capture mouse");
+#endif
 			vidc_framecount = 0;
 			if (!fullscreen)
 				SDL_SetWindowTitle(sdl_main_window, s);


### PR DESCRIPTION
## Summary

- replace the version- and architecture-specific `mac-setup` flow with a small Homebrew/Autoreconf setup script
- default Darwin builds to the native wxWidgets main window and avoid the X11/XQuartz dependency on macOS
- marshal window title and resize operations onto the wx event thread, fixing Cocoa main-thread crashes
- reject incomplete startup dimensions, centre the first usable macOS mode, and preserve window geometry across later mode changes
- add working native fullscreen, Cmd-Backspace input release, exact window-frame restoration, and graceful macOS Quit handling
- keep existing compiler flags, use a pre-C23 C mode for the legacy C sources, and build podules by default as documented
- document the macOS build and ignore generated build/runtime files

wxWidgets 3.3 no longer installs its Autoconf macros, so this vendors the unmodified `wxwin.m4` from the wxWidgets 3.3.3 release. Generated Autotools output is deliberately not included in the patch.

## Window-handling fixes

VIDC emits transient invalid resize requests (including negative widths and zero heights) before the first usable video mode. Passing these to Cocoa moved the wx frame offscreen, after which valid resizes inherited the bad position. The wx handler now ignores incomplete dimensions, avoids repeated native resizes, centres the first valid mode, and restores the saved frame rectangle after fullscreen.

Switching between the SDL and wx configure modes can also leave executables and common object files built with the previous source list and `UI_WX` flags. `mac-setup` now runs the normal `make clean` target after configuring so the subsequent build cannot mix backends.

## Validation

Tested on Apple Silicon with macOS 26.6.1, Xcode 26.6, wxWidgets 3.3.3, SDL2 compatibility 2.32.70, Autoconf 2.73, and Automake 1.18.1.

- `./mac-setup --enable-debug`
- `make -j"$(sysctl -n hw.logicalcpu)"` (including all bundled podules)
- `./configure --enable-debug --disable-wx-main-window` followed by a full build of the SDL fallback
- switched from an existing SDL build back through `mac-setup`, verified that backend-dependent objects were cleaned, and rebuilt the native wx executable
- booted RISC OS 3.11 in an `AXStandardWindow` with close, fullscreen, and minimize controls
- verified centred startup bounds of `(544, 284, 640, 544)` on a 1728×1117 logical display
- moved the window and confirmed repeated emulator resize notifications did not change its position
- entered fullscreen at `(0, -33, 1728, 1149)` and returned with Cmd-Backspace to the exact prior `(544, 284, 640, 544)` frame
- quit through the macOS application menu with a clean process exit
- `bash -n mac-setup`
